### PR TITLE
fix(ci): replace curl pre-download with node-based hardhat compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,17 +28,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/hardhat-nodejs
-          key: hardhat-compilers-solc-0.8.28
+          key: hardhat-compilers-v2-solc-0.8.28
 
-      - name: Pre-download solc binary
+      - name: Warm Hardhat compiler cache (Node.js)
         if: steps.cache-hardhat.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p ~/.cache/hardhat-nodejs/compilers-v3/linux-amd64
-          curl -sfL "https://binaries.soliditylang.org/linux-amd64/list.json" \
-            -o ~/.cache/hardhat-nodejs/compilers-v3/linux-amd64/list.json
-          curl -sfL "https://binaries.soliditylang.org/linux-amd64/solc-linux-amd64-v0.8.28+commit.7893614a" \
-            -o ~/.cache/hardhat-nodejs/compilers-v3/linux-amd64/solc-linux-amd64-v0.8.28+commit.7893614a
-          chmod +x ~/.cache/hardhat-nodejs/compilers-v3/linux-amd64/solc-linux-amd64-v0.8.28+commit.7893614a
+        working-directory: packages/mcp-compiler
+        # Use Node.js (not Bun) to trigger Hardhat's own download machinery.
+        # Bun has a known Linux webstreams_adapters crash in Hardhat's fetch-based
+        # compiler downloader; Node.js does not. Hardhat manages its own cache layout
+        # and verification metadata, so the cached binary is trusted on subsequent runs.
+        run: node node_modules/.bin/hardhat compile
 
       - name: Run CI verification
         run: bun run ci:full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,20 @@ jobs:
           path: ~/.cache/hardhat-nodejs
           key: hardhat-compilers-v2-solc-0.8.28
 
+      - name: Setup Node.js 22 (for Hardhat cache warm-up)
+        if: steps.cache-hardhat.outputs.cache-hit != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Warm Hardhat compiler cache (Node.js)
         if: steps.cache-hardhat.outputs.cache-hit != 'true'
         working-directory: packages/mcp-compiler
-        # Use Node.js (not Bun) to trigger Hardhat's own download machinery.
+        # Use Node.js 22 (not Bun) to trigger Hardhat's own download machinery.
         # Bun has a known Linux webstreams_adapters crash in Hardhat's fetch-based
-        # compiler downloader; Node.js does not. Hardhat manages its own cache layout
-        # and verification metadata, so the cached binary is trusted on subsequent runs.
+        # compiler downloader; Node.js does not. Node.js 22 is required because
+        # Hardhat 3.x uses Iterator.prototype.flatMap which only landed in Node.js 22
+        # (ubuntu-latest ships Node.js 20 by default).
         run: node node_modules/.bin/hardhat compile
 
       - name: Run CI verification

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,14 @@ jobs:
 
       - name: Cache Hardhat compiler binaries
         id: cache-hardhat
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/hardhat-nodejs
           key: hardhat-compilers-v2-solc-0.8.28
 
       - name: Setup Node.js 22 (for Hardhat cache warm-up)
         if: steps.cache-hardhat.outputs.cache-hit != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/packages/mcp-compiler/hardhat.config.js
+++ b/packages/mcp-compiler/hardhat.config.js
@@ -1,0 +1,11 @@
+// Minimal Hardhat config used only to warm the compiler binary cache in CI.
+// The actual compilation uses createHardhatRuntimeEnvironment programmatically
+// in src/compiler.ts — this config is not loaded at runtime.
+import { defineConfig } from 'hardhat/config';
+
+export default defineConfig({
+  solidity: '0.8.28',
+  paths: {
+    sources: './test/fixtures',
+  },
+});


### PR DESCRIPTION
## Problem

CI was flaky after merge because the `curl` pre-download workaround was fragile:

- Placed raw binaries in Hardhat's cache directory without the **verification metadata** Hardhat writes alongside each binary. On cache hit, Hardhat trusted the files; on any miss or partial cache, it tried to re-verify via network — triggering the Bun `webstreams_adapters` crash.
- Hardcoded the binary filename (`solc-linux-amd64-v0.8.28+commit.7893614a`) — any toolchain update breaks the path.
- Increasing timeouts doesn't help: the underlying error is a **crash** (`webstreams_adapters`), not a slowdown. Bun's `ReadableStream` implementation on Linux is incompatible with Hardhat's fetch-based compiler downloader.

## Fix

Replace the curl step with:

```yaml
working-directory: packages/mcp-compiler
run: node node_modules/.bin/hardhat compile
```

Using **Node.js** (not Bun) to run `hardhat compile` against a minimal `hardhat.config.js`:

- Node.js does not have the webstreams bug
- Hardhat manages its own cache layout, checksums, and verification metadata — the resulting cache is fully trusted on subsequent hits with no re-verification needed
- Compiles `test/fixtures/Counter.sol` with solc 0.8.28, confirming the full pipeline end-to-end
- Self-healing: if Hardhat's cache format changes across versions, it just re-downloads correctly

Also bumped the Actions cache key to `v2` to bust stale incomplete caches from the previous curl approach.

## Verification

Tested locally: `node node_modules/.bin/hardhat compile` from `packages/mcp-compiler` outputs:
```
Compiled 1 Solidity file with solc 0.8.28 (evm target: cancun)
```