### PR TITLE
feat: implement backend control plane (Issue #11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ artifacts/
 cache/
 
 # Backend generated files (Prisma client) — see packages/backend/.gitignore
+.workspaces

--- a/bun.lock
+++ b/bun.lock
@@ -23,10 +23,26 @@
         "typescript-eslint": "^8.59.0",
       },
     },
+    "packages/agent": {
+      "name": "@crucible/agent",
+      "version": "0.0.0",
+      "dependencies": {
+        "@ai-sdk/openai": "^3.0.0",
+        "@crucible/types": "workspace:*",
+        "ai": "^6.0.168",
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.7.3",
+      },
+    },
     "packages/backend": {
       "name": "@crucible/backend",
       "version": "0.0.0",
       "dependencies": {
+        "@0glabs/0g-serving-broker": "^0.7.5",
+        "@crucible/agent": "workspace:*",
         "@crucible/types": "workspace:*",
         "@hono/zod-openapi": "^1.3.0",
         "@prisma/adapter-pg": "^7.8.0",
@@ -34,7 +50,9 @@
         "better-auth": "^1.6.9",
         "dockerode": "^4.0.9",
         "dotenv": "^17.4.2",
+        "ethers": "^6.13.0",
         "hono": "^4.12.15",
+        "node-pty": "^1.1.0",
         "pg": "^8.20.0",
         "zod": "^4.0.0",
       },
@@ -166,9 +184,13 @@
     },
   },
   "packages": {
-    "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
+    "@0glabs/0g-serving-broker": ["@0glabs/0g-serving-broker@0.7.5", "", { "dependencies": { "@ethersproject/bytes": "^5.7.0", "@ethersproject/keccak256": "^5.7.0", "adm-zip": "^0.5.16", "axios": "^1.7.9", "brotli": "^1.3.3", "buffer": "^6.0.3", "chalk": "^4.1.2", "circomlibjs": "^0.1.6", "cli-table3": "^0.6.5", "commander": "^13.0.0", "crypto-browserify": "^3.12.1", "crypto-js": "^4.2.0", "dotenv": "16.4.7", "eciesjs": "^0.4.13", "express": "5.1.0", "form-data": "^4.0.1", "prompts": "^2.4.2", "stream-browserify": "^3.0.0", "tslib": "^2.6.2", "update-notifier": "^7.3.1", "util": "^0.12.5" }, "peerDependencies": { "@types/circomlibjs": "^0.1.6", "@types/crypto-js": "^4.2.2", "ethers": "^6.13.1" }, "bin": { "0g-compute-cli": "cli.commonjs/cli/index.js" } }, "sha512-pT4eBgf/WsvswDgZxahpl5aVBKuT7mb3L+2oD4Zi9DLIerzZvMwMjldWpcOFH+9WqgbZh3l4fgLcp5foHeU1LA=="],
+
+    "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.10.1", "", {}, "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="],
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.104", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA=="],
+
+    "@ai-sdk/openai": ["@ai-sdk/openai@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
 
@@ -248,6 +270,10 @@
 
     "@codemirror/view": ["@codemirror/view@6.41.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg=="],
 
+    "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
+
+    "@crucible/agent": ["@crucible/agent@workspace:packages/agent"],
+
     "@crucible/backend": ["@crucible/backend@workspace:packages/backend"],
 
     "@crucible/frontend": ["@crucible/frontend@workspace:packages/frontend"],
@@ -269,6 +295,8 @@
     "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.3", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg=="],
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
+
+    "@ecies/ciphers": ["@ecies/ciphers@0.2.6", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g=="],
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.4.1", "", {}, "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q=="],
 
@@ -352,6 +380,66 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.1", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ=="],
 
+    "@ethersproject/abi": ["@ethersproject/abi@5.8.0", "", { "dependencies": { "@ethersproject/address": "^5.8.0", "@ethersproject/bignumber": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/constants": "^5.8.0", "@ethersproject/hash": "^5.8.0", "@ethersproject/keccak256": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/properties": "^5.8.0", "@ethersproject/strings": "^5.8.0" } }, "sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q=="],
+
+    "@ethersproject/abstract-provider": ["@ethersproject/abstract-provider@5.8.0", "", { "dependencies": { "@ethersproject/bignumber": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/networks": "^5.8.0", "@ethersproject/properties": "^5.8.0", "@ethersproject/transactions": "^5.8.0", "@ethersproject/web": "^5.8.0" } }, "sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg=="],
+
+    "@ethersproject/abstract-signer": ["@ethersproject/abstract-signer@5.8.0", "", { "dependencies": { "@ethersproject/abstract-provider": "^5.8.0", "@ethersproject/bignumber": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/properties": "^5.8.0" } }, "sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA=="],
+
+    "@ethersproject/address": ["@ethersproject/address@5.8.0", "", { "dependencies": { "@ethersproject/bignumber": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/keccak256": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/rlp": "^5.8.0" } }, "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA=="],
+
+    "@ethersproject/base64": ["@ethersproject/base64@5.8.0", "", { "dependencies": { "@ethersproject/bytes": "^5.8.0" } }, "sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ=="],
+
+    "@ethersproject/basex": ["@ethersproject/basex@5.8.0", "", { "dependencies": { "@ethersproject/bytes": "^5.8.0", "@ethersproject/properties": "^5.8.0" } }, "sha512-PIgTszMlDRmNwW9nhS6iqtVfdTAKosA7llYXNmGPw4YAI1PUyMv28988wAb41/gHF/WqGdoLv0erHaRcHRKW2Q=="],
+
+    "@ethersproject/bignumber": ["@ethersproject/bignumber@5.8.0", "", { "dependencies": { "@ethersproject/bytes": "^5.8.0", "@ethersproject/logger": "^5.8.0", "bn.js": "^5.2.1" } }, "sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA=="],
+
+    "@ethersproject/bytes": ["@ethersproject/bytes@5.8.0", "", { "dependencies": { "@ethersproject/logger": "^5.8.0" } }, "sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A=="],
+
+    "@ethersproject/constants": ["@ethersproject/constants@5.8.0", "", { "dependencies": { "@ethersproject/bignumber": "^5.8.0" } }, "sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg=="],
+
+    "@ethersproject/contracts": ["@ethersproject/contracts@5.8.0", "", { "dependencies": { "@ethersproject/abi": "^5.8.0", "@ethersproject/abstract-provider": "^5.8.0", "@ethersproject/abstract-signer": "^5.8.0", "@ethersproject/address": "^5.8.0", "@ethersproject/bignumber": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/constants": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/properties": "^5.8.0", "@ethersproject/transactions": "^5.8.0" } }, "sha512-0eFjGz9GtuAi6MZwhb4uvUM216F38xiuR0yYCjKJpNfSEy4HUM8hvqqBj9Jmm0IUz8l0xKEhWwLIhPgxNY0yvQ=="],
+
+    "@ethersproject/hash": ["@ethersproject/hash@5.8.0", "", { "dependencies": { "@ethersproject/abstract-signer": "^5.8.0", "@ethersproject/address": "^5.8.0", "@ethersproject/base64": "^5.8.0", "@ethersproject/bignumber": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/keccak256": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/properties": "^5.8.0", "@ethersproject/strings": "^5.8.0" } }, "sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA=="],
+
+    "@ethersproject/hdnode": ["@ethersproject/hdnode@5.8.0", "", { "dependencies": { "@ethersproject/abstract-signer": "^5.8.0", "@ethersproject/basex": "^5.8.0", "@ethersproject/bignumber": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/pbkdf2": "^5.8.0", "@ethersproject/properties": "^5.8.0", "@ethersproject/sha2": "^5.8.0", "@ethersproject/signing-key": "^5.8.0", "@ethersproject/strings": "^5.8.0", "@ethersproject/transactions": "^5.8.0", "@ethersproject/wordlists": "^5.8.0" } }, "sha512-4bK1VF6E83/3/Im0ERnnUeWOY3P1BZml4ZD3wcH8Ys0/d1h1xaFt6Zc+Dh9zXf9TapGro0T4wvO71UTCp3/uoA=="],
+
+    "@ethersproject/json-wallets": ["@ethersproject/json-wallets@5.8.0", "", { "dependencies": { "@ethersproject/abstract-signer": "^5.8.0", "@ethersproject/address": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/hdnode": "^5.8.0", "@ethersproject/keccak256": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/pbkdf2": "^5.8.0", "@ethersproject/properties": "^5.8.0", "@ethersproject/random": "^5.8.0", "@ethersproject/strings": "^5.8.0", "@ethersproject/transactions": "^5.8.0", "aes-js": "3.0.0", "scrypt-js": "3.0.1" } }, "sha512-HxblNck8FVUtNxS3VTEYJAcwiKYsBIF77W15HufqlBF9gGfhmYOJtYZp8fSDZtn9y5EaXTE87zDwzxRoTFk11w=="],
+
+    "@ethersproject/keccak256": ["@ethersproject/keccak256@5.8.0", "", { "dependencies": { "@ethersproject/bytes": "^5.8.0", "js-sha3": "0.8.0" } }, "sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng=="],
+
+    "@ethersproject/logger": ["@ethersproject/logger@5.8.0", "", {}, "sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA=="],
+
+    "@ethersproject/networks": ["@ethersproject/networks@5.8.0", "", { "dependencies": { "@ethersproject/logger": "^5.8.0" } }, "sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg=="],
+
+    "@ethersproject/pbkdf2": ["@ethersproject/pbkdf2@5.8.0", "", { "dependencies": { "@ethersproject/bytes": "^5.8.0", "@ethersproject/sha2": "^5.8.0" } }, "sha512-wuHiv97BrzCmfEaPbUFpMjlVg/IDkZThp9Ri88BpjRleg4iePJaj2SW8AIyE8cXn5V1tuAaMj6lzvsGJkGWskg=="],
+
+    "@ethersproject/properties": ["@ethersproject/properties@5.8.0", "", { "dependencies": { "@ethersproject/logger": "^5.8.0" } }, "sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw=="],
+
+    "@ethersproject/providers": ["@ethersproject/providers@5.8.0", "", { "dependencies": { "@ethersproject/abstract-provider": "^5.8.0", "@ethersproject/abstract-signer": "^5.8.0", "@ethersproject/address": "^5.8.0", "@ethersproject/base64": "^5.8.0", "@ethersproject/basex": "^5.8.0", "@ethersproject/bignumber": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/constants": "^5.8.0", "@ethersproject/hash": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/networks": "^5.8.0", "@ethersproject/properties": "^5.8.0", "@ethersproject/random": "^5.8.0", "@ethersproject/rlp": "^5.8.0", "@ethersproject/sha2": "^5.8.0", "@ethersproject/strings": "^5.8.0", "@ethersproject/transactions": "^5.8.0", "@ethersproject/web": "^5.8.0", "bech32": "1.1.4", "ws": "8.18.0" } }, "sha512-3Il3oTzEx3o6kzcg9ZzbE+oCZYyY+3Zh83sKkn4s1DZfTUjIegHnN2Cm0kbn9YFy45FDVcuCLLONhU7ny0SsCw=="],
+
+    "@ethersproject/random": ["@ethersproject/random@5.8.0", "", { "dependencies": { "@ethersproject/bytes": "^5.8.0", "@ethersproject/logger": "^5.8.0" } }, "sha512-E4I5TDl7SVqyg4/kkA/qTfuLWAQGXmSOgYyO01So8hLfwgKvYK5snIlzxJMk72IFdG/7oh8yuSqY2KX7MMwg+A=="],
+
+    "@ethersproject/rlp": ["@ethersproject/rlp@5.8.0", "", { "dependencies": { "@ethersproject/bytes": "^5.8.0", "@ethersproject/logger": "^5.8.0" } }, "sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q=="],
+
+    "@ethersproject/sha2": ["@ethersproject/sha2@5.8.0", "", { "dependencies": { "@ethersproject/bytes": "^5.8.0", "@ethersproject/logger": "^5.8.0", "hash.js": "1.1.7" } }, "sha512-dDOUrXr9wF/YFltgTBYS0tKslPEKr6AekjqDW2dbn1L1xmjGR+9GiKu4ajxovnrDbwxAKdHjW8jNcwfz8PAz4A=="],
+
+    "@ethersproject/signing-key": ["@ethersproject/signing-key@5.8.0", "", { "dependencies": { "@ethersproject/bytes": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/properties": "^5.8.0", "bn.js": "^5.2.1", "elliptic": "6.6.1", "hash.js": "1.1.7" } }, "sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w=="],
+
+    "@ethersproject/solidity": ["@ethersproject/solidity@5.8.0", "", { "dependencies": { "@ethersproject/bignumber": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/keccak256": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/sha2": "^5.8.0", "@ethersproject/strings": "^5.8.0" } }, "sha512-4CxFeCgmIWamOHwYN9d+QWGxye9qQLilpgTU0XhYs1OahkclF+ewO+3V1U0mvpiuQxm5EHHmv8f7ClVII8EHsA=="],
+
+    "@ethersproject/strings": ["@ethersproject/strings@5.8.0", "", { "dependencies": { "@ethersproject/bytes": "^5.8.0", "@ethersproject/constants": "^5.8.0", "@ethersproject/logger": "^5.8.0" } }, "sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg=="],
+
+    "@ethersproject/transactions": ["@ethersproject/transactions@5.8.0", "", { "dependencies": { "@ethersproject/address": "^5.8.0", "@ethersproject/bignumber": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/constants": "^5.8.0", "@ethersproject/keccak256": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/properties": "^5.8.0", "@ethersproject/rlp": "^5.8.0", "@ethersproject/signing-key": "^5.8.0" } }, "sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg=="],
+
+    "@ethersproject/units": ["@ethersproject/units@5.8.0", "", { "dependencies": { "@ethersproject/bignumber": "^5.8.0", "@ethersproject/constants": "^5.8.0", "@ethersproject/logger": "^5.8.0" } }, "sha512-lxq0CAnc5kMGIiWW4Mr041VT8IhNM+Pn5T3haO74XZWFulk7wH1Gv64HqE96hT4a7iiNMdOCFEBgaxWuk8ETKQ=="],
+
+    "@ethersproject/wallet": ["@ethersproject/wallet@5.8.0", "", { "dependencies": { "@ethersproject/abstract-provider": "^5.8.0", "@ethersproject/abstract-signer": "^5.8.0", "@ethersproject/address": "^5.8.0", "@ethersproject/bignumber": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/hash": "^5.8.0", "@ethersproject/hdnode": "^5.8.0", "@ethersproject/json-wallets": "^5.8.0", "@ethersproject/keccak256": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/properties": "^5.8.0", "@ethersproject/random": "^5.8.0", "@ethersproject/signing-key": "^5.8.0", "@ethersproject/transactions": "^5.8.0", "@ethersproject/wordlists": "^5.8.0" } }, "sha512-G+jnzmgg6UxurVKRKvw27h0kvG75YKXZKdlLYmAHeF32TGUzHkOFd7Zn6QHOTYRFWnfjtSSFjBowKo7vfrXzPA=="],
+
+    "@ethersproject/web": ["@ethersproject/web@5.8.0", "", { "dependencies": { "@ethersproject/base64": "^5.8.0", "@ethersproject/bytes": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/properties": "^5.8.0", "@ethersproject/strings": "^5.8.0" } }, "sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw=="],
+
+    "@ethersproject/wordlists": ["@ethersproject/wordlists@5.8.0", "", { "dependencies": { "@ethersproject/bytes": "^5.8.0", "@ethersproject/hash": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/properties": "^5.8.0", "@ethersproject/strings": "^5.8.0" } }, "sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg=="],
+
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
@@ -432,7 +520,7 @@
 
     "@noble/ciphers": ["@noble/ciphers@2.2.0", "", {}, "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="],
 
-    "@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+    "@noble/curves": ["@noble/curves@1.2.0", "", { "dependencies": { "@noble/hashes": "1.3.2" } }, "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw=="],
 
     "@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
 
@@ -481,6 +569,12 @@
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+
+    "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
+
+    "@pnpm/network.ca-file": ["@pnpm/network.ca-file@1.0.2", "", { "dependencies": { "graceful-fs": "4.2.10" } }, "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA=="],
+
+    "@pnpm/npm-conf": ["@pnpm/npm-conf@3.0.2", "", { "dependencies": { "@pnpm/config.env-replace": "^1.1.0", "@pnpm/network.ca-file": "^1.0.1", "config-chain": "^1.1.11" } }, "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -728,7 +822,11 @@
 
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
+    "@types/circomlibjs": ["@types/circomlibjs@0.1.6", "", {}, "sha512-yF174bPDaiKgejlZzCSqKwZaqXhlxMcVEHrAtstFohwP05OjtvHXOdxO6HQeTg8WwIdgMg7MJb1WyWZdUCGlPQ=="],
+
     "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
+
+    "@types/crypto-js": ["@types/crypto-js@4.2.2", "", {}, "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ=="],
 
     "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
 
@@ -856,15 +954,21 @@
 
     "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
-    "adm-zip": ["adm-zip@0.4.16", "", {}, "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg=="],
+    "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
+
+    "aes-js": ["aes-js@4.0.0-beta.5", "", {}, "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="],
 
     "ai": ["ai@6.0.168", "", { "dependencies": { "@ai-sdk/gateway": "3.0.104", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ=="],
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "ansi-align": ["ansi-align@3.0.1", "", { "dependencies": { "string-width": "^4.1.0" } }, "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
@@ -872,21 +976,35 @@
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
 
     "asn1": ["asn1@0.2.6", "", { "dependencies": { "safer-buffer": "~2.1.0" } }, "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ=="],
 
+    "asn1.js": ["asn1.js@4.10.1", "", { "dependencies": { "bn.js": "^4.0.0", "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0" } }, "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "atomically": ["atomically@2.1.1", "", { "dependencies": { "stubborn-fs": "^2.0.0", "when-exit": "^2.1.4" } }, "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ=="],
+
+    "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
+
     "aws-ssl-profiles": ["aws-ssl-profiles@1.1.2", "", {}, "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="],
 
+    "axios": ["axios@1.15.2", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A=="],
+
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "b4a": ["b4a@1.8.0", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "bcrypt-pbkdf": ["bcrypt-pbkdf@1.0.2", "", { "dependencies": { "tweetnacl": "^0.14.3" } }, "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w=="],
+
+    "bech32": ["bech32@1.1.4", "", {}, "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="],
 
     "better-auth": ["better-auth@1.6.9", "", { "dependencies": { "@better-auth/core": "1.6.9", "@better-auth/drizzle-adapter": "1.6.9", "@better-auth/kysely-adapter": "1.6.9", "@better-auth/memory-adapter": "1.6.9", "@better-auth/mongo-adapter": "1.6.9", "@better-auth/prisma-adapter": "1.6.9", "@better-auth/telemetry": "1.6.9", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.5", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.14", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": "^0.45.2", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-EBFURtglyiEZxbx4NJBoqUD8J65dX24yC+6I9AUbIXNgUkt76mshzGbHkxZ3n/lB7Dwq3kBC+hHt0hUQsnL7HA=="],
 
@@ -900,19 +1018,57 @@
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
+    "blake-hash": ["blake-hash@2.0.0", "", { "dependencies": { "node-addon-api": "^3.0.0", "node-gyp-build": "^4.2.2", "readable-stream": "^3.6.0" } }, "sha512-Igj8YowDu1PRkRsxZA7NVkdFNxH5rKv5cpLxQ0CVXSIA77pVYwCPRQJ2sMew/oneUpfuYRyjG6r8SmmmnbZb1w=="],
+
+    "blake2b": ["blake2b@2.1.4", "", { "dependencies": { "blake2b-wasm": "^2.4.0", "nanoassert": "^2.0.0" } }, "sha512-AyBuuJNI64gIvwx13qiICz6H6hpmjvYS5DGkG6jbXMOT8Z3WUJ3V1X0FlhIoT1b/5JtHE3ki+xjtMvu1nn+t9A=="],
+
+    "blake2b-wasm": ["blake2b-wasm@2.4.0", "", { "dependencies": { "b4a": "^1.0.1", "nanoassert": "^2.0.0" } }, "sha512-S1kwmW2ZhZFFFOghcx73+ZajEfKBqhP82JMssxtLVMxlaPea1p9uoLiUZ5WYyHn0KddwbLc+0vh4wR0KBNoT5w=="],
+
+    "bn.js": ["bn.js@5.2.3", "", {}, "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "boxen": ["boxen@8.0.1", "", { "dependencies": { "ansi-align": "^3.0.1", "camelcase": "^8.0.0", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "string-width": "^7.2.0", "type-fest": "^4.21.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0" } }, "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw=="],
+
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
-    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+    "brorand": ["brorand@1.1.0", "", {}, "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="],
+
+    "brotli": ["brotli@1.3.3", "", { "dependencies": { "base64-js": "^1.1.2" } }, "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg=="],
+
+    "browserify-aes": ["browserify-aes@1.2.0", "", { "dependencies": { "buffer-xor": "^1.0.3", "cipher-base": "^1.0.0", "create-hash": "^1.1.0", "evp_bytestokey": "^1.0.3", "inherits": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA=="],
+
+    "browserify-cipher": ["browserify-cipher@1.0.1", "", { "dependencies": { "browserify-aes": "^1.0.4", "browserify-des": "^1.0.0", "evp_bytestokey": "^1.0.0" } }, "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w=="],
+
+    "browserify-des": ["browserify-des@1.0.2", "", { "dependencies": { "cipher-base": "^1.0.1", "des.js": "^1.0.0", "inherits": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A=="],
+
+    "browserify-rsa": ["browserify-rsa@4.1.1", "", { "dependencies": { "bn.js": "^5.2.1", "randombytes": "^2.1.0", "safe-buffer": "^5.2.1" } }, "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ=="],
+
+    "browserify-sign": ["browserify-sign@4.2.5", "", { "dependencies": { "bn.js": "^5.2.2", "browserify-rsa": "^4.1.1", "create-hash": "^1.2.0", "create-hmac": "^1.1.7", "elliptic": "^6.6.1", "inherits": "^2.0.4", "parse-asn1": "^5.1.9", "readable-stream": "^2.3.8", "safe-buffer": "^5.2.1" } }, "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw=="],
+
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
+    "buffer-xor": ["buffer-xor@1.0.3", "", {}, "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="],
 
     "buildcheck": ["buildcheck@0.0.7", "", {}, "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA=="],
 
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "c12": ["c12@3.3.4", "", { "dependencies": { "chokidar": "^5.0.0", "confbox": "^0.2.4", "defu": "^6.1.6", "dotenv": "^17.3.1", "exsolve": "^1.0.8", "giget": "^3.2.0", "jiti": "^2.6.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.1.0", "pkg-types": "^2.3.0", "rc9": "^3.0.1" }, "peerDependencies": { "magicast": "*" }, "optionalPeers": ["magicast"] }, "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA=="],
+
+    "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "camelcase": ["camelcase@8.0.0", "", {}, "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
-    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
 
@@ -928,7 +1084,15 @@
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
+    "cipher-base": ["cipher-base@1.0.7", "", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.2" } }, "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA=="],
+
+    "circomlibjs": ["circomlibjs@0.1.7", "", { "dependencies": { "blake-hash": "^2.0.0", "blake2b": "^2.1.3", "ethers": "^5.5.1", "ffjavascript": "^0.2.45" } }, "sha512-GRAUoAlKAsiiTa+PA725G9RmEmJJRc8tRFxw/zKktUxlQISGznT4hH4ESvW8FNTsrGg/nNd06sGP/Wlx0LUHVg=="],
+
+    "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
+
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "cli-table3": ["cli-table3@0.6.5", "", { "dependencies": { "string-width": "^4.2.0" }, "optionalDependencies": { "@colors/colors": "1.5.0" } }, "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ=="],
 
     "cli-truncate": ["cli-truncate@5.2.0", "", { "dependencies": { "slice-ansi": "^8.0.0", "string-width": "^8.2.0" } }, "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw=="],
 
@@ -944,6 +1108,8 @@
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
@@ -952,15 +1118,37 @@
 
     "confbox": ["confbox@0.2.4", "", {}, "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="],
 
+    "config-chain": ["config-chain@1.1.13", "", { "dependencies": { "ini": "^1.3.4", "proto-list": "~1.2.1" } }, "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ=="],
+
+    "configstore": ["configstore@7.1.0", "", { "dependencies": { "atomically": "^2.0.3", "dot-prop": "^9.0.0", "graceful-fs": "^4.2.11", "xdg-basedir": "^5.1.0" } }, "sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
     "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
 
     "cpu-features": ["cpu-features@0.0.10", "", { "dependencies": { "buildcheck": "~0.0.6", "nan": "^2.19.0" } }, "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA=="],
 
+    "create-ecdh": ["create-ecdh@4.0.4", "", { "dependencies": { "bn.js": "^4.1.0", "elliptic": "^6.5.3" } }, "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A=="],
+
+    "create-hash": ["create-hash@1.2.0", "", { "dependencies": { "cipher-base": "^1.0.1", "inherits": "^2.0.1", "md5.js": "^1.3.4", "ripemd160": "^2.0.1", "sha.js": "^2.4.0" } }, "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg=="],
+
+    "create-hmac": ["create-hmac@1.1.7", "", { "dependencies": { "cipher-base": "^1.0.3", "create-hash": "^1.1.0", "inherits": "^2.0.1", "ripemd160": "^2.0.0", "safe-buffer": "^5.0.1", "sha.js": "^2.4.8" } }, "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg=="],
+
     "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "crypto-browserify": ["crypto-browserify@3.12.1", "", { "dependencies": { "browserify-cipher": "^1.0.1", "browserify-sign": "^4.2.3", "create-ecdh": "^4.0.4", "create-hash": "^1.2.0", "create-hmac": "^1.1.7", "diffie-hellman": "^5.0.3", "hash-base": "~3.0.4", "inherits": "^2.0.4", "pbkdf2": "^3.1.2", "public-encrypt": "^4.0.3", "randombytes": "^2.1.0", "randomfill": "^1.0.4" } }, "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ=="],
+
+    "crypto-js": ["crypto-js@4.2.0", "", {}, "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="],
 
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
@@ -1048,19 +1236,29 @@
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
+
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "deepmerge-ts": ["deepmerge-ts@7.1.5", "", {}, "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw=="],
 
+    "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
+
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
     "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
 
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
     "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "des.js": ["des.js@1.1.0", "", { "dependencies": { "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0" } }, "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg=="],
 
     "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
 
@@ -1070,19 +1268,33 @@
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
+    "diffie-hellman": ["diffie-hellman@5.0.3", "", { "dependencies": { "bn.js": "^4.1.0", "miller-rabin": "^4.0.0", "randombytes": "^2.0.0" } }, "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg=="],
+
     "docker-modem": ["docker-modem@5.0.7", "", { "dependencies": { "debug": "^4.1.1", "readable-stream": "^3.5.0", "split-ca": "^1.0.1", "ssh2": "^1.15.0" } }, "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA=="],
 
     "dockerode": ["dockerode@4.0.12", "", { "dependencies": { "@balena/dockerignore": "^1.0.2", "@grpc/grpc-js": "^1.11.1", "@grpc/proto-loader": "^0.7.13", "docker-modem": "^5.0.7", "protobufjs": "^7.3.2", "tar-fs": "^2.1.4", "uuid": "^10.0.0" } }, "sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw=="],
 
     "dompurify": ["dompurify@3.4.1", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw=="],
 
+    "dot-prop": ["dot-prop@9.0.0", "", { "dependencies": { "type-fest": "^4.18.2" } }, "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ=="],
+
     "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "eciesjs": ["eciesjs@0.4.18", "", { "dependencies": { "@ecies/ciphers": "^0.2.5", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.7", "@noble/hashes": "^1.8.0" } }, "sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "effect": ["effect@3.20.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw=="],
 
-    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+    "elliptic": ["elliptic@6.6.1", "", { "dependencies": { "bn.js": "^4.11.9", "brorand": "^1.1.0", "hash.js": "^1.0.0", "hmac-drbg": "^1.0.1", "inherits": "^2.0.4", "minimalistic-assert": "^1.0.1", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
@@ -1096,11 +1308,21 @@
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-goat": ["escape-goat@4.0.0", "", {}, "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -1130,11 +1352,19 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
     "ethereum-cryptography": ["ethereum-cryptography@2.2.1", "", { "dependencies": { "@noble/curves": "1.4.2", "@noble/hashes": "1.4.0", "@scure/bip32": "1.4.0", "@scure/bip39": "1.3.0" } }, "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg=="],
+
+    "ethers": ["ethers@6.16.0", "", { "dependencies": { "@adraffy/ens-normalize": "1.10.1", "@noble/curves": "1.2.0", "@noble/hashes": "1.3.2", "@types/node": "22.7.5", "aes-js": "4.0.0-beta.5", "tslib": "2.7.0", "ws": "8.17.1" } }, "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A=="],
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
+
+    "evp_bytestokey": ["evp_bytestokey@1.0.3", "", { "dependencies": { "md5.js": "^1.3.4", "safe-buffer": "^5.1.1" } }, "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA=="],
+
+    "express": ["express@5.1.0", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.0", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA=="],
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
@@ -1152,7 +1382,11 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "ffjavascript": ["ffjavascript@0.2.63", "", { "dependencies": { "wasmbuilder": "0.0.16", "wasmcurves": "0.2.2", "web-worker": "1.2.0" } }, "sha512-dBgdsfGks58b66JnUZeZpGxdMIDQ4QsD3VYlRJyFVrKQHb2kJy4R2gufx5oetrTxXPT+aEjg0dOvOLg1N0on4A=="],
+
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -1160,7 +1394,17 @@
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
+    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
+
+    "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
+
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
@@ -1170,11 +1414,17 @@
 
     "generate-function": ["generate-function@2.3.1", "", { "dependencies": { "is-property": "^1.0.2" } }, "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ=="],
 
+    "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
+
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
     "get-port-please": ["get-port-please@3.2.0", "", {}, "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
@@ -1182,7 +1432,11 @@
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
+    "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
+
     "globals": ["globals@17.5.0", "", {}, "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
@@ -1194,17 +1448,33 @@
 
     "hardhat": ["hardhat@3.4.1", "", { "dependencies": { "@nomicfoundation/edr": "0.12.0-next.29", "@nomicfoundation/hardhat-errors": "^3.0.11", "@nomicfoundation/hardhat-utils": "^4.0.4", "@nomicfoundation/hardhat-vendored": "^3.0.2", "@nomicfoundation/hardhat-zod-utils": "^3.0.4", "@nomicfoundation/solidity-analyzer": "^0.1.1", "@sentry/core": "^9.4.0", "adm-zip": "^0.4.16", "chalk": "^5.3.0", "chokidar": "^4.0.3", "debug": "^4.3.2", "enquirer": "^2.3.0", "ethereum-cryptography": "^2.2.1", "micro-eth-signer": "^0.14.0", "p-map": "^7.0.2", "resolve.exports": "^2.0.3", "semver": "^7.6.3", "tsx": "^4.19.3", "ws": "^8.18.0", "zod": "^3.23.8" }, "bin": { "hardhat": "dist/src/cli.js" } }, "sha512-4dEmiI8m/foqofaDDZYGD88TPXAxz9UY9wHEjNfrCO2hFIcoNpqXScSPr95WuMZyb+iAh/FL4A3lFq6W9Qcnmw=="],
 
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hash-base": ["hash-base@3.0.5", "", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1" } }, "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg=="],
+
+    "hash.js": ["hash.js@1.1.7", "", { "dependencies": { "inherits": "^2.0.3", "minimalistic-assert": "^1.0.1" } }, "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA=="],
+
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
+    "hmac-drbg": ["hmac-drbg@1.0.1", "", { "dependencies": { "hash.js": "^1.0.3", "minimalistic-assert": "^1.0.0", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg=="],
+
     "hono": ["hono@4.12.15", "", {}, "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "http-status-codes": ["http-status-codes@2.3.0", "", {}, "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA=="],
 
@@ -1218,25 +1488,51 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
+    "ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
+
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-arguments": ["is-arguments@1.2.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA=="],
+
+    "is-callable": ["is-callable@1.2.7", "", {}, "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="],
 
     "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
+    "is-in-ci": ["is-in-ci@1.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg=="],
+
+    "is-installed-globally": ["is-installed-globally@1.0.0", "", { "dependencies": { "global-directory": "^4.0.1", "is-path-inside": "^4.0.0" } }, "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ=="],
+
     "is-module": ["is-module@1.0.0", "", {}, "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g=="],
 
+    "is-npm": ["is-npm@6.1.0", "", {}, "sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA=="],
+
+    "is-path-inside": ["is-path-inside@4.0.0", "", {}, "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA=="],
+
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-property": ["is-property@1.0.2", "", {}, "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="],
 
     "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
+
+    "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
+
+    "is-typed-array": ["is-typed-array@1.1.15", "", { "dependencies": { "which-typed-array": "^1.1.16" } }, "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ=="],
+
+    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -1247,6 +1543,8 @@
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "js-sha3": ["js-sha3@0.8.0", "", {}, "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="],
 
     "jsdom": ["jsdom@29.0.2", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.5", "@asamuzakjp/dom-selector": "^7.0.6", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.1", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.24.5", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w=="],
 
@@ -1270,9 +1568,13 @@
 
     "known-css-properties": ["known-css-properties@0.37.0", "", {}, "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ=="],
 
+    "ky": ["ky@1.14.3", "", {}, "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw=="],
+
     "kysely": ["kysely@0.28.16", "", {}, "sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww=="],
 
     "langium": ["langium@4.2.2", "", { "dependencies": { "@chevrotain/regexp-to-ast": "~12.0.0", "chevrotain": "~12.0.0", "chevrotain-allstar": "~0.4.1", "vscode-languageserver": "~9.0.1", "vscode-languageserver-textdocument": "~1.0.11", "vscode-uri": "~3.1.0" } }, "sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ=="],
+
+    "latest-version": ["latest-version@9.0.0", "", { "dependencies": { "package-json": "^10.0.0" } }, "sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA=="],
 
     "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
 
@@ -1330,9 +1632,17 @@
 
     "marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "md5.js": ["md5.js@1.3.5", "", { "dependencies": { "hash-base": "^3.0.0", "inherits": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg=="],
+
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
 
     "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "mermaid": ["mermaid@11.14.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.1", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.1.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.1", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.19", "dompurify": "^3.3.1", "katex": "^0.16.25", "khroma": "^2.1.0", "lodash-es": "^4.17.23", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0" } }, "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g=="],
 
@@ -1350,9 +1660,21 @@
 
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
+    "miller-rabin": ["miller-rabin@4.0.1", "", { "dependencies": { "bn.js": "^4.0.0", "brorand": "^1.0.1" }, "bin": { "miller-rabin": "bin/miller-rabin" } }, "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
+    "minimalistic-assert": ["minimalistic-assert@1.0.1", "", {}, "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="],
+
+    "minimalistic-crypto-utils": ["minimalistic-crypto-utils@1.0.1", "", {}, "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="],
+
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
@@ -1372,17 +1694,31 @@
 
     "nan": ["nan@2.26.2", "", {}, "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw=="],
 
+    "nanoassert": ["nanoassert@2.0.0", "", {}, "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="],
+
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "nanostores": ["nanostores@1.3.0", "", {}, "sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
+
+    "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
@@ -1404,11 +1740,17 @@
 
     "p-map": ["p-map@7.0.4", "", {}, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
 
+    "package-json": ["package-json@10.0.1", "", { "dependencies": { "ky": "^1.2.0", "registry-auth-token": "^5.0.2", "registry-url": "^6.0.1", "semver": "^7.6.0" } }, "sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg=="],
+
     "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
     "paneforge": ["paneforge@1.0.2", "", { "dependencies": { "runed": "^0.23.4", "svelte-toolbelt": "^0.9.2" }, "peerDependencies": { "svelte": "^5.29.0" } }, "sha512-KzmIXQH1wCfwZ4RsMohD/IUtEjVhteR+c+ulb/CHYJHX8SuDXoJmChtsc/Xs5Wl8NHS4L5Q7cxL8MG40gSU1bA=="],
 
+    "parse-asn1": ["parse-asn1@5.1.9", "", { "dependencies": { "asn1.js": "^4.10.1", "browserify-aes": "^1.2.0", "evp_bytestokey": "^1.0.3", "pbkdf2": "^3.1.5", "safe-buffer": "^5.2.1" } }, "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg=="],
+
     "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
 
@@ -1418,7 +1760,11 @@
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pbkdf2": ["pbkdf2@3.1.5", "", { "dependencies": { "create-hash": "^1.2.0", "create-hmac": "^1.1.7", "ripemd160": "^2.0.3", "safe-buffer": "^5.2.1", "sha.js": "^2.4.12", "to-buffer": "^1.2.1" } }, "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ=="],
 
     "perfect-debounce": ["perfect-debounce@2.1.0", "", {}, "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g=="],
 
@@ -1452,6 +1798,8 @@
 
     "portless": ["portless@0.10.3", "", { "os": [ "linux", "win32", "darwin", ], "bin": { "portless": "dist/cli.js" } }, "sha512-lXbVUsNiwWMKJGMi49HhTMW0lS7u0EzawonDZQ+yglSnHioiQK18Y4Fe0Ilk+TuXej71E/nTOHIFIBjUGvTm9w=="],
 
+    "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
+
     "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
 
     "postcss-load-config": ["postcss-load-config@3.1.4", "", { "dependencies": { "lilconfig": "^2.0.5", "yaml": "^1.10.2" }, "peerDependencies": { "postcss": ">=8.0.9", "ts-node": ">=9.0.0" }, "optionalPeers": ["postcss", "ts-node"] }, "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg=="],
@@ -1482,17 +1830,43 @@
 
     "prisma": ["prisma@7.8.0", "", { "dependencies": { "@prisma/config": "7.8.0", "@prisma/dev": "0.24.3", "@prisma/engines": "7.8.0", "@prisma/studio-core": "0.27.3", "mysql2": "3.15.3", "postgres": "3.4.7" }, "peerDependencies": { "better-sqlite3": ">=9.0.0", "typescript": ">=5.4.0" }, "optionalPeers": ["better-sqlite3", "typescript"], "bin": { "prisma": "build/index.js" } }, "sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw=="],
 
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
+    "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
+
     "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
+    "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
+
     "protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
+
+    "public-encrypt": ["public-encrypt@4.0.3", "", { "dependencies": { "bn.js": "^4.1.0", "browserify-rsa": "^4.0.0", "create-hash": "^1.1.0", "parse-asn1": "^5.0.0", "randombytes": "^2.0.1", "safe-buffer": "^5.1.2" } }, "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q=="],
 
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
+    "pupa": ["pupa@3.3.0", "", { "dependencies": { "escape-goat": "^4.0.0" } }, "sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA=="],
+
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
+
+    "randomfill": ["randomfill@1.0.4", "", { "dependencies": { "randombytes": "^2.0.5", "safe-buffer": "^5.1.0" } }, "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
     "rc9": ["rc9@3.0.1", "", { "dependencies": { "defu": "^6.1.6", "destr": "^2.0.5" } }, "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ=="],
 
@@ -1509,6 +1883,10 @@
     "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "registry-auth-token": ["registry-auth-token@5.1.1", "", { "dependencies": { "@pnpm/npm-conf": "^3.0.2" } }, "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q=="],
+
+    "registry-url": ["registry-url@6.0.1", "", { "dependencies": { "rc": "1.2.8" } }, "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q=="],
 
     "remeda": ["remeda@2.33.4", "", {}, "sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ=="],
 
@@ -1528,6 +1906,8 @@
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
+    "ripemd160": ["ripemd160@2.0.3", "", { "dependencies": { "hash-base": "^3.1.2", "inherits": "^2.0.4" } }, "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA=="],
+
     "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
 
     "rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
@@ -1538,6 +1918,8 @@
 
     "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "runed": ["runed@0.37.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0", "zod": "^4.1.0" }, "optionalPeers": ["@sveltejs/kit", "zod"] }, "sha512-MeFY73xBW8IueWBm012nNFIGy19WUGPLtknavyUPMpnyt350M47PhGSGrGoSLbidwn+Zlt/O0cp8/OZE3LASWA=="],
 
     "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
@@ -1546,17 +1928,31 @@
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
+    "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
+    "scrypt-js": ["scrypt-js@3.0.1", "", {}, "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="],
+
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
     "seq-queue": ["seq-queue@0.0.5", "", {}, "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="],
 
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
     "set-cookie-parser": ["set-cookie-parser@3.1.0", "", {}, "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw=="],
+
+    "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "sha.js": ["sha.js@2.4.12", "", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.0" }, "bin": { "sha.js": "bin.js" } }, "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w=="],
 
     "shadcn-svelte": ["shadcn-svelte@1.2.7", "", { "dependencies": { "commander": "^14.0.0", "node-fetch-native": "^1.6.4", "postcss": "^8.5.5", "tailwind-merge": "^3.0.0" }, "peerDependencies": { "svelte": "^5.0.0" }, "bin": { "shadcn-svelte": "dist/index.mjs" } }, "sha512-mWuQk4H4gtV+J2wJQ7nEPKNnB/v86AALFryZU0SSM7ChHmJJMZ1kH+qIuxYKrXm9vOOOcSWHRsWzPDB71DnjYA=="],
 
@@ -1566,9 +1962,19 @@
 
     "shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
 
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
 
@@ -1584,11 +1990,15 @@
 
     "ssh2": ["ssh2@1.17.0", "", { "dependencies": { "asn1": "^0.2.6", "bcrypt-pbkdf": "^1.0.2" }, "optionalDependencies": { "cpu-features": "~0.0.10", "nan": "^2.23.0" } }, "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ=="],
 
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "stream-browserify": ["stream-browserify@3.0.0", "", { "dependencies": { "inherits": "~2.0.4", "readable-stream": "^3.5.0" } }, "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA=="],
 
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
-    "string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
@@ -1596,11 +2006,19 @@
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
+    "stubborn-fs": ["stubborn-fs@2.0.0", "", { "dependencies": { "stubborn-utils": "^1.0.1" } }, "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA=="],
+
+    "stubborn-utils": ["stubborn-utils@1.0.2", "", {}, "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg=="],
+
     "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
     "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
@@ -1638,6 +2056,10 @@
 
     "tldts-core": ["tldts-core@7.0.28", "", {}, "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ=="],
 
+    "to-buffer": ["to-buffer@1.2.2", "", { "dependencies": { "isarray": "^2.0.5", "safe-buffer": "^5.2.1", "typed-array-buffer": "^1.0.3" } }, "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
     "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
@@ -1662,6 +2084,12 @@
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
+    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "typescript-eslint": ["typescript-eslint@8.59.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.0", "@typescript-eslint/parser": "8.59.0", "@typescript-eslint/typescript-estree": "8.59.0", "@typescript-eslint/utils": "8.59.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw=="],
@@ -1682,13 +2110,21 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "update-notifier": ["update-notifier@7.3.1", "", { "dependencies": { "boxen": "^8.0.1", "chalk": "^5.3.0", "configstore": "^7.0.0", "is-in-ci": "^1.0.0", "is-installed-globally": "^1.0.0", "is-npm": "^6.0.0", "latest-version": "^9.0.0", "pupa": "^3.1.0", "semver": "^7.6.3", "xdg-basedir": "^5.1.0" } }, "sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA=="],
+
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "util": ["util@0.12.5", "", { "dependencies": { "inherits": "^2.0.3", "is-arguments": "^1.0.4", "is-generator-function": "^1.0.7", "is-typed-array": "^1.1.3", "which-typed-array": "^1.1.2" } }, "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "valibot": ["valibot@1.2.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
@@ -1716,13 +2152,25 @@
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
+    "wasmbuilder": ["wasmbuilder@0.0.16", "", {}, "sha512-Qx3lEFqaVvp1cEYW7Bfi+ebRJrOiwz2Ieu7ZG2l7YyeSJIok/reEQCQCuicj/Y32ITIJuGIM9xZQppGx5LrQdA=="],
+
+    "wasmcurves": ["wasmcurves@0.2.2", "", { "dependencies": { "wasmbuilder": "0.0.16" } }, "sha512-JRY908NkmKjFl4ytnTu5ED6AwPD+8VJ9oc94kdq7h5bIwbj0L4TDJ69mG+2aLs2SoCmGfqIesMWTEJjtYsoQXQ=="],
+
+    "web-worker": ["web-worker@1.2.0", "", {}, "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="],
+
     "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 
     "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
 
     "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
+    "when-exit": ["when-exit@2.1.5", "", {}, "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
+
+    "widest-line": ["widest-line@5.0.0", "", { "dependencies": { "string-width": "^7.0.0" } }, "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
@@ -1730,7 +2178,9 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+    "ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
+
+    "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
@@ -1756,17 +2206,29 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@0glabs/0g-serving-broker/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
+
+    "@0glabs/0g-serving-broker/dotenv": ["dotenv@16.4.7", "", {}, "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="],
+
     "@crucible/frontend/typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "@ecies/ciphers/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
+    "@ethersproject/json-wallets/aes-js": ["aes-js@3.0.0", "", {}, "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="],
+
+    "@ethersproject/providers/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
     "@grpc/grpc-js/@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
 
-    "@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+    "@noble/curves/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
 
     "@nomicfoundation/hardhat-utils/undici": ["undici@6.25.0", "", {}, "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg=="],
 
     "@nomicfoundation/hardhat-zod-utils/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
 
     "@prisma/engines/@prisma/get-platform": ["@prisma/get-platform@7.8.0", "", { "dependencies": { "@prisma/debug": "7.8.0" } }, "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw=="],
 
@@ -1783,6 +2245,8 @@
     "@rollup/plugin-commonjs/is-reference": ["is-reference@1.2.1", "", { "dependencies": { "@types/estree": "*" } }, "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@scure/bip32/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@scure/bip32/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -1804,13 +2268,31 @@
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
+    "asn1.js/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
+
     "bits-ui/runed": ["runed@0.35.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0" }, "optionalPeers": ["@sveltejs/kit"] }, "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q=="],
+
+    "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "blake-hash/node-addon-api": ["node-addon-api@3.2.1", "", {}, "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="],
+
+    "boxen/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "boxen/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "browserify-sign/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "c12/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
-    "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "circomlibjs/ethers": ["ethers@5.8.0", "", { "dependencies": { "@ethersproject/abi": "5.8.0", "@ethersproject/abstract-provider": "5.8.0", "@ethersproject/abstract-signer": "5.8.0", "@ethersproject/address": "5.8.0", "@ethersproject/base64": "5.8.0", "@ethersproject/basex": "5.8.0", "@ethersproject/bignumber": "5.8.0", "@ethersproject/bytes": "5.8.0", "@ethersproject/constants": "5.8.0", "@ethersproject/contracts": "5.8.0", "@ethersproject/hash": "5.8.0", "@ethersproject/hdnode": "5.8.0", "@ethersproject/json-wallets": "5.8.0", "@ethersproject/keccak256": "5.8.0", "@ethersproject/logger": "5.8.0", "@ethersproject/networks": "5.8.0", "@ethersproject/pbkdf2": "5.8.0", "@ethersproject/properties": "5.8.0", "@ethersproject/providers": "5.8.0", "@ethersproject/random": "5.8.0", "@ethersproject/rlp": "5.8.0", "@ethersproject/sha2": "5.8.0", "@ethersproject/signing-key": "5.8.0", "@ethersproject/solidity": "5.8.0", "@ethersproject/strings": "5.8.0", "@ethersproject/transactions": "5.8.0", "@ethersproject/units": "5.8.0", "@ethersproject/wallet": "5.8.0", "@ethersproject/web": "5.8.0", "@ethersproject/wordlists": "5.8.0" } }, "sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg=="],
+
+    "cli-truncate/string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "config-chain/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "create-ecdh/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
 
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 
@@ -1822,6 +2304,16 @@
 
     "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
 
+    "diffie-hellman/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
+
+    "eciesjs/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
+    "eciesjs/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
+
+    "eciesjs/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "elliptic/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
+
     "eslint-plugin-svelte/globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
 
     "ethereum-cryptography/@noble/curves": ["@noble/curves@1.4.2", "", { "dependencies": { "@noble/hashes": "1.4.0" } }, "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw=="],
@@ -1832,6 +2324,22 @@
 
     "ethereum-cryptography/@scure/bip39": ["@scure/bip39@1.3.0", "", { "dependencies": { "@noble/hashes": "~1.4.0", "@scure/base": "~1.1.6" } }, "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ=="],
 
+    "ethers/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
+
+    "ethers/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
+
+    "ethers/tslib": ["tslib@2.7.0", "", {}, "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="],
+
+    "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "hardhat/adm-zip": ["adm-zip@0.4.16", "", {}, "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg=="],
+
+    "hardhat/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "hardhat/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
     "hardhat/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
@@ -1840,11 +2348,15 @@
 
     "log-update/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
+    "md5.js/hash-base": ["hash-base@3.1.2", "", { "dependencies": { "inherits": "^2.0.4", "readable-stream": "^2.3.8", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.1" } }, "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg=="],
+
     "mermaid/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "micro-eth-signer/@noble/curves": ["@noble/curves@1.8.2", "", { "dependencies": { "@noble/hashes": "1.7.2" } }, "sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g=="],
 
     "micro-eth-signer/@noble/hashes": ["@noble/hashes@1.7.2", "", {}, "sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ=="],
+
+    "miller-rabin/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
 
     "mlly/pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
@@ -1852,7 +2364,11 @@
 
     "mode-watcher/svelte-toolbelt": ["svelte-toolbelt@0.7.1", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.23.2", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ=="],
 
+    "ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
+
     "ox/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
+    "ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "ox/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -1866,9 +2382,19 @@
 
     "postcss-load-config/yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 
+    "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
     "proper-lockfile/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
-    "string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+    "public-encrypt/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
+
+    "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "ripemd160/hash-base": ["hash-base@3.1.2", "", { "dependencies": { "inherits": "^2.0.4", "readable-stream": "^2.3.8", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.1" } }, "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg=="],
+
+    "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "svelte-eslint-parser/eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 
@@ -1884,27 +2410,39 @@
 
     "svelte-toolbelt/runed": ["runed@0.35.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0" }, "optionalPeers": ["@sveltejs/kit"] }, "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q=="],
 
+    "to-buffer/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+
+    "update-notifier/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
     "viem/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "viem/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+
+    "widest-line/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
-    "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
     "@prisma/streams-local/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@types/ssh2/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
+    "boxen/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "boxen/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "browserify-sign/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "browserify-sign/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
     "c12/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
-    "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "cliui/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
-
-    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "cli-truncate/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
 
@@ -1916,7 +2454,17 @@
 
     "ethereum-cryptography/@scure/bip39/@scure/base": ["@scure/base@1.1.9", "", {}, "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg=="],
 
+    "ethers/@types/node/undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+
+    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "log-update/slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
     "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "md5.js/hash-base/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "mlly/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
@@ -1924,7 +2472,7 @@
 
     "paneforge/svelte-toolbelt/runed": ["runed@0.29.2", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-0cq6cA6sYGZwl/FvVqjx9YN+1xEBu9sDDyuWdDW1yWX7JF2wmvmVKfH+hVCZs+csW+P3ARH92MjI3H9QTagOQA=="],
 
-    "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "ripemd160/hash-base/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "svelte-streamdown/@shikijs/langs/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
 
@@ -1938,10 +2486,26 @@
 
     "svelte-streamdown/shiki/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
 
+    "widest-line/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "widest-line/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
-    "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "boxen/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
-    "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+    "cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "md5.js/hash-base/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "md5.js/hash-base/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "ripemd160/hash-base/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "ripemd160/hash-base/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "widest-line/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-svelte": "^3.17.1",
         "globals": "^17.5.0",
+        "hardhat": "^3.4.2",
         "lint-staged": "^16.4.0",
         "portless": "^0.10.3",
         "prettier": "^3.4.2",
@@ -602,7 +603,7 @@
 
     "@nomicfoundation/hardhat-errors": ["@nomicfoundation/hardhat-errors@3.0.11", "", { "dependencies": { "@nomicfoundation/hardhat-utils": "^4.0.3" } }, "sha512-XEKplQ+FhZD1PgIGSj62scoqB/y+uG8x+V+U68m1a+4L1I46y4/gZQGIuMLkRZeqhPHsLle6ykDB+vn8qtwqzw=="],
 
-    "@nomicfoundation/hardhat-utils": ["@nomicfoundation/hardhat-utils@4.0.4", "", { "dependencies": { "@streamparser/json-node": "^0.0.22", "debug": "^4.3.2", "env-paths": "^2.2.0", "ethereum-cryptography": "^2.2.1", "fast-equals": "^5.4.0", "json-stream-stringify": "^3.1.6", "rfdc": "^1.3.1", "undici": "^6.16.1" } }, "sha512-CClEwrfcHsAsF9CNJfqJIBRSNTDi2pgGc0s2Bo5qGtIuh8YwgI9mpkMyzJzi/lHFuDFtEA+Oi2AfX6qRDp+SIw=="],
+    "@nomicfoundation/hardhat-utils": ["@nomicfoundation/hardhat-utils@4.0.5", "", { "dependencies": { "@streamparser/json-node": "^0.0.22", "debug": "^4.3.2", "env-paths": "^2.2.0", "ethereum-cryptography": "^2.2.1", "fast-equals": "^5.4.0", "json-stream-stringify": "^3.1.6", "rfdc": "^1.3.1", "undici": "^6.16.1" } }, "sha512-+M4gdNhj5zqElduDckzFza4oBXEwYaLdMeJuIqprDwb4iQkDxLVeKQgIWFp1SdRCqJ116QSDYFVZApznHdcoZg=="],
 
     "@nomicfoundation/hardhat-vendored": ["@nomicfoundation/hardhat-vendored@3.0.2", "", {}, "sha512-v65aSwA0k15QzMUL4cFXT2CPnrjrxR1BE2V24BjNCPnlhwI/2e1Gfy7TaIGSor5yZGeiQ5ScI+wP/ovKxQBr0g=="],
 
@@ -1020,7 +1021,7 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
-    "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
+    "adm-zip": ["adm-zip@0.4.16", "", {}, "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg=="],
 
     "aes-js": ["aes-js@4.0.0-beta.5", "", {}, "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="],
 
@@ -1128,7 +1129,7 @@
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
-    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
 
@@ -1506,7 +1507,7 @@
 
     "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
 
-    "hardhat": ["hardhat@3.4.1", "", { "dependencies": { "@nomicfoundation/edr": "0.12.0-next.29", "@nomicfoundation/hardhat-errors": "^3.0.11", "@nomicfoundation/hardhat-utils": "^4.0.4", "@nomicfoundation/hardhat-vendored": "^3.0.2", "@nomicfoundation/hardhat-zod-utils": "^3.0.4", "@nomicfoundation/solidity-analyzer": "^0.1.1", "@sentry/core": "^9.4.0", "adm-zip": "^0.4.16", "chalk": "^5.3.0", "chokidar": "^4.0.3", "debug": "^4.3.2", "enquirer": "^2.3.0", "ethereum-cryptography": "^2.2.1", "micro-eth-signer": "^0.14.0", "p-map": "^7.0.2", "resolve.exports": "^2.0.3", "semver": "^7.6.3", "tsx": "^4.19.3", "ws": "^8.18.0", "zod": "^3.23.8" }, "bin": { "hardhat": "dist/src/cli.js" } }, "sha512-4dEmiI8m/foqofaDDZYGD88TPXAxz9UY9wHEjNfrCO2hFIcoNpqXScSPr95WuMZyb+iAh/FL4A3lFq6W9Qcnmw=="],
+    "hardhat": ["hardhat@3.4.2", "", { "dependencies": { "@nomicfoundation/edr": "0.12.0-next.29", "@nomicfoundation/hardhat-errors": "^3.0.11", "@nomicfoundation/hardhat-utils": "^4.0.5", "@nomicfoundation/hardhat-vendored": "^3.0.2", "@nomicfoundation/hardhat-zod-utils": "^3.0.4", "@nomicfoundation/solidity-analyzer": "^0.1.1", "@sentry/core": "^9.4.0", "adm-zip": "^0.4.16", "chalk": "^5.3.0", "chokidar": "^4.0.3", "debug": "^4.3.2", "enquirer": "^2.3.0", "ethereum-cryptography": "^2.2.1", "micro-eth-signer": "^0.14.0", "p-map": "^7.0.2", "resolve.exports": "^2.0.3", "semver": "^7.6.3", "tsx": "^4.19.3", "ws": "^8.18.0", "zod": "^3.23.8" }, "bin": { "hardhat": "dist/src/cli.js" } }, "sha512-6NUzfGFwHdaAvNmSwsZngH1vuUd8MWN92yTM4uo2VsrRGF5bsF1GWbZd7+UJO6/8zYOwViEbWYu7J4ypmSNr/g=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -2158,7 +2159,7 @@
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
-    "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
+    "undici": ["undici@6.25.0", "", {}, "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -2240,7 +2241,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
 
@@ -2268,11 +2269,19 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@0glabs/0g-serving-broker/adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
+
+    "@0glabs/0g-serving-broker/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
     "@0glabs/0g-serving-broker/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 
     "@0glabs/0g-serving-broker/dotenv": ["dotenv@16.4.7", "", {}, "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="],
 
     "@crucible/frontend/typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "@crucible/mcp-chain/hardhat": ["hardhat@3.4.1", "", { "dependencies": { "@nomicfoundation/edr": "0.12.0-next.29", "@nomicfoundation/hardhat-errors": "^3.0.11", "@nomicfoundation/hardhat-utils": "^4.0.4", "@nomicfoundation/hardhat-vendored": "^3.0.2", "@nomicfoundation/hardhat-zod-utils": "^3.0.4", "@nomicfoundation/solidity-analyzer": "^0.1.1", "@sentry/core": "^9.4.0", "adm-zip": "^0.4.16", "chalk": "^5.3.0", "chokidar": "^4.0.3", "debug": "^4.3.2", "enquirer": "^2.3.0", "ethereum-cryptography": "^2.2.1", "micro-eth-signer": "^0.14.0", "p-map": "^7.0.2", "resolve.exports": "^2.0.3", "semver": "^7.6.3", "tsx": "^4.19.3", "ws": "^8.18.0", "zod": "^3.23.8" }, "bin": { "hardhat": "dist/src/cli.js" } }, "sha512-4dEmiI8m/foqofaDDZYGD88TPXAxz9UY9wHEjNfrCO2hFIcoNpqXScSPr95WuMZyb+iAh/FL4A3lFq6W9Qcnmw=="],
+
+    "@crucible/mcp-compiler/hardhat": ["hardhat@3.4.1", "", { "dependencies": { "@nomicfoundation/edr": "0.12.0-next.29", "@nomicfoundation/hardhat-errors": "^3.0.11", "@nomicfoundation/hardhat-utils": "^4.0.4", "@nomicfoundation/hardhat-vendored": "^3.0.2", "@nomicfoundation/hardhat-zod-utils": "^3.0.4", "@nomicfoundation/solidity-analyzer": "^0.1.1", "@sentry/core": "^9.4.0", "adm-zip": "^0.4.16", "chalk": "^5.3.0", "chokidar": "^4.0.3", "debug": "^4.3.2", "enquirer": "^2.3.0", "ethereum-cryptography": "^2.2.1", "micro-eth-signer": "^0.14.0", "p-map": "^7.0.2", "resolve.exports": "^2.0.3", "semver": "^7.6.3", "tsx": "^4.19.3", "ws": "^8.18.0", "zod": "^3.23.8" }, "bin": { "hardhat": "dist/src/cli.js" } }, "sha512-4dEmiI8m/foqofaDDZYGD88TPXAxz9UY9wHEjNfrCO2hFIcoNpqXScSPr95WuMZyb+iAh/FL4A3lFq6W9Qcnmw=="],
 
     "@ecies/ciphers/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
@@ -2286,7 +2295,9 @@
 
     "@noble/curves/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
 
-    "@nomicfoundation/hardhat-utils/undici": ["undici@6.25.0", "", {}, "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg=="],
+    "@nomicfoundation/hardhat-errors/@nomicfoundation/hardhat-utils": ["@nomicfoundation/hardhat-utils@4.0.4", "", { "dependencies": { "@streamparser/json-node": "^0.0.22", "debug": "^4.3.2", "env-paths": "^2.2.0", "ethereum-cryptography": "^2.2.1", "fast-equals": "^5.4.0", "json-stream-stringify": "^3.1.6", "rfdc": "^1.3.1", "undici": "^6.16.1" } }, "sha512-CClEwrfcHsAsF9CNJfqJIBRSNTDi2pgGc0s2Bo5qGtIuh8YwgI9mpkMyzJzi/lHFuDFtEA+Oi2AfX6qRDp+SIw=="],
+
+    "@nomicfoundation/hardhat-zod-utils/@nomicfoundation/hardhat-utils": ["@nomicfoundation/hardhat-utils@4.0.4", "", { "dependencies": { "@streamparser/json-node": "^0.0.22", "debug": "^4.3.2", "env-paths": "^2.2.0", "ethereum-cryptography": "^2.2.1", "fast-equals": "^5.4.0", "json-stream-stringify": "^3.1.6", "rfdc": "^1.3.1", "undici": "^6.16.1" } }, "sha512-CClEwrfcHsAsF9CNJfqJIBRSNTDi2pgGc0s2Bo5qGtIuh8YwgI9mpkMyzJzi/lHFuDFtEA+Oi2AfX6qRDp+SIw=="],
 
     "@nomicfoundation/hardhat-zod-utils/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -2337,8 +2348,6 @@
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "blake-hash/node-addon-api": ["node-addon-api@3.2.1", "", {}, "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="],
-
-    "boxen/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "boxen/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
@@ -2392,17 +2401,15 @@
 
     "ethers/tslib": ["tslib@2.7.0", "", {}, "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="],
 
+    "ethers/ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
+
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
-    "hardhat/adm-zip": ["adm-zip@0.4.16", "", {}, "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg=="],
-
-    "hardhat/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
-
-    "hardhat/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
-
     "hardhat/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "jsdom/undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
@@ -2474,8 +2481,6 @@
 
     "to-buffer/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
 
-    "update-notifier/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
-
     "viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "viem/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
@@ -2489,6 +2494,14 @@
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "@crucible/mcp-chain/hardhat/@nomicfoundation/hardhat-utils": ["@nomicfoundation/hardhat-utils@4.0.4", "", { "dependencies": { "@streamparser/json-node": "^0.0.22", "debug": "^4.3.2", "env-paths": "^2.2.0", "ethereum-cryptography": "^2.2.1", "fast-equals": "^5.4.0", "json-stream-stringify": "^3.1.6", "rfdc": "^1.3.1", "undici": "^6.16.1" } }, "sha512-CClEwrfcHsAsF9CNJfqJIBRSNTDi2pgGc0s2Bo5qGtIuh8YwgI9mpkMyzJzi/lHFuDFtEA+Oi2AfX6qRDp+SIw=="],
+
+    "@crucible/mcp-chain/hardhat/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@crucible/mcp-compiler/hardhat/@nomicfoundation/hardhat-utils": ["@nomicfoundation/hardhat-utils@4.0.4", "", { "dependencies": { "@streamparser/json-node": "^0.0.22", "debug": "^4.3.2", "env-paths": "^2.2.0", "ethereum-cryptography": "^2.2.1", "fast-equals": "^5.4.0", "json-stream-stringify": "^3.1.6", "rfdc": "^1.3.1", "undici": "^6.16.1" } }, "sha512-CClEwrfcHsAsF9CNJfqJIBRSNTDi2pgGc0s2Bo5qGtIuh8YwgI9mpkMyzJzi/lHFuDFtEA+Oi2AfX6qRDp+SIw=="],
+
+    "@crucible/mcp-compiler/hardhat/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@prisma/streams-local/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
       "name": "@crucible/agent",
       "version": "0.0.0",
       "dependencies": {
+        "@ai-sdk/mcp": "^1.0.36",
         "@ai-sdk/openai": "^3.0.0",
         "@crucible/types": "workspace:*",
         "ai": "^6.0.168",
@@ -240,6 +241,8 @@
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.10.1", "", {}, "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="],
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.104", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA=="],
+
+    "@ai-sdk/mcp": ["@ai-sdk/mcp@1.0.36", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "pkce-challenge": "^5.0.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-THQKwlknp7OU2ViLPfIU7W01XvDRM2eqH+4UULQgP64AopnwI9mGqqJeGIx2l/pxUu9yIDQtW9YtYM8kHm2CQg=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ=="],
 
@@ -1846,6 +1849,8 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-svelte": "^3.17.1",
     "globals": "^17.5.0",
+    "hardhat": "^3.4.2",
     "lint-staged": "^16.4.0",
     "portless": "^0.10.3",
     "prettier": "^3.4.2",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@crucible/agent",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "echo 'Bun runtime — no compile step'",
+    "check-types": "tsc --noEmit",
+    "lint": "eslint .",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "^3.0.0",
+    "@crucible/types": "workspace:*",
+    "ai": "^6.0.168",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -16,6 +16,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@ai-sdk/mcp": "^1.0.36",
     "@ai-sdk/openai": "^3.0.0",
     "@crucible/types": "workspace:*",
     "ai": "^6.0.168",

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @crucible/agent — public API
+ *
+ * Exports the agentic loop entry point and its supporting types.
+ * The backend imports `runAgentTurn` and supplies an `AgentAdapter`
+ * implementation that bridges the loop to the Prisma DB, PTY manager,
+ * workspace-fs, tool-exec proxy, and agent-bus.
+ */
+
+export { runAgentTurn } from './loop.ts';
+export type { AgentAdapter, AgentConfig, ShellResult } from './loop.ts';

--- a/packages/agent/src/loop.ts
+++ b/packages/agent/src/loop.ts
@@ -19,6 +19,7 @@ import {
   InferenceReceiptIdSchema,
   StreamIdSchema,
   type AgentEvent,
+  type FallbackReason,
   type WorkspaceFile,
 } from '@crucible/types';
 import { buildSystemPrompt } from './system-prompt.ts';
@@ -40,6 +41,12 @@ export interface AgentConfig {
    * Defaults to 'openai-compatible' when not set.
    */
   provider?: '0g-compute' | 'openai-compatible';
+  /**
+   * Why inference fell back from the primary provider (0G Compute) to the
+   * OpenAI-compatible path. Null when 0G is the active provider. Surfaced
+   * in the inference_receipt event so the UI can show honest fallback state.
+   */
+  fallbackReason?: FallbackReason | null;
 }
 
 /** Shell execution result returned by adapter.runShell. */
@@ -314,7 +321,8 @@ export async function runAgentTurn(
       provider: config.provider ?? 'openai-compatible',
       model: config.model,
       attestation: null,
-      fallbackReason: config.provider === '0g-compute' ? null : 'admin_override',
+      fallbackReason:
+        config.provider === '0g-compute' ? null : (config.fallbackReason ?? 'admin_override'),
       promptTokens,
       completionTokens,
       createdAt: Date.now(),

--- a/packages/agent/src/loop.ts
+++ b/packages/agent/src/loop.ts
@@ -193,6 +193,7 @@ export async function runAgentTurn(
   // ── MCP client setup ───────────────────────────────────────────────────────
   const mcpClients: MCPClient[] = [];
   const mcpToolNames = new Set<string>();
+  const toolToServer = new Map<string, string>(); // toolName → serverName for event emission
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const mcpToolsObj: Record<string, any> = {};
   for (const [serverName, url] of Object.entries(config.mcpServerUrls ?? {})) {
@@ -200,11 +201,13 @@ export async function runAgentTurn(
     try {
       const client = await createMCPClient({ transport: { type: 'http', url } });
       mcpClients.push(client);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const serverTools = await client.tools({
-        schemas: getMcpSchemas(serverName as McpServerKey) as any,
+        schemas: getMcpSchemas(serverName as McpServerKey) as any, // eslint-disable-line @typescript-eslint/no-explicit-any
       });
-      for (const name of Object.keys(serverTools)) mcpToolNames.add(name);
+      for (const name of Object.keys(serverTools)) {
+        mcpToolNames.add(name);
+        toolToServer.set(name, serverName);
+      }
       Object.assign(mcpToolsObj, serverTools);
     } catch (err) {
       console.warn(
@@ -328,11 +331,12 @@ export async function runAgentTurn(
           if (mcpToolNames.has(chunk.toolName)) {
             const callId = CallIdSchema.parse(crypto.randomUUID());
             pendingMcpCalls.set(chunk.toolCallId, callId);
+            const serverName = toolToServer.get(chunk.toolName) ?? 'mcp';
             emit({
               ...baseEvent(),
               type: 'tool_call',
               callId,
-              tool: chunk.toolName,
+              tool: `${serverName}.${chunk.toolName}`,
               args: chunk.input as Record<string, unknown>,
             });
           }

--- a/packages/agent/src/loop.ts
+++ b/packages/agent/src/loop.ts
@@ -1,0 +1,325 @@
+/**
+ * Core agentic loop for Crucible.
+ *
+ * Uses the Vercel AI SDK v6 `streamText` with an OpenAI-compatible provider.
+ * Tools (read_file, write_file, run_shell, mcp_tool) are backed by injected
+ * adapter functions so this module has no hard dependency on the backend's
+ * Prisma client, PTY manager, or agent-bus — making it independently testable.
+ *
+ * The loop runs up to 20 model steps (`stopWhen: stepCountIs(20)`) and
+ * publishes `AgentEvent`s to the bus via `adapter.publishEvent` so the
+ * frontend's SSE stream receives live updates.
+ */
+
+import { streamText, tool, stepCountIs } from 'ai';
+import { createOpenAI } from '@ai-sdk/openai';
+import { z } from 'zod';
+import {
+  CallIdSchema,
+  InferenceReceiptIdSchema,
+  StreamIdSchema,
+  type AgentEvent,
+  type WorkspaceFile,
+} from '@crucible/types';
+import { buildSystemPrompt } from './system-prompt.ts';
+
+// ── Public types ─────────────────────────────────────────────────────────────
+
+/** OpenAI-compatible inference provider configuration. */
+export interface AgentConfig {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+  /**
+   * Extra HTTP headers injected on every request.
+   * Used for 0G Compute per-request signed auth headers.
+   */
+  headers?: Record<string, string>;
+  /**
+   * Which provider is serving this turn.
+   * Defaults to 'openai-compatible' when not set.
+   */
+  provider?: '0g-compute' | 'openai-compatible';
+}
+
+/** Shell execution result returned by adapter.runShell. */
+export interface ShellResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/**
+ * All backend service calls the agent loop requires, injected by the caller.
+ *
+ * Using an adapter interface instead of direct imports keeps packages/agent
+ * free of circular dependencies with packages/backend.
+ */
+export interface AgentAdapter {
+  /** Return the current files in the workspace (used for context injection). */
+  getWorkspaceFiles(workspaceId: string): Promise<WorkspaceFile[]>;
+
+  /**
+   * Write `content` to `filePath` (workspace-relative) and return the
+   * resulting `WorkspaceFile` metadata (path, lang, hash, modifiedAt, …).
+   */
+  writeFile(workspaceId: string, filePath: string, content: string): Promise<WorkspaceFile>;
+
+  /** Run `cmd` in a shell scoped to the workspace directory. */
+  runShell(workspaceId: string, cmd: string): Promise<ShellResult>;
+
+  /** Proxy a tool call to one of the workspace's MCP microservices. */
+  executeMcpTool(
+    workspaceId: string,
+    server: string,
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<unknown>;
+
+  /** Publish an event to the agent bus for this workspace. */
+  publishEvent(workspaceId: string, event: AgentEvent): void;
+
+  /** Allocate the next monotonic sequence number for this workspace's stream. */
+  nextSeq(workspaceId: string): number;
+}
+
+// ── Main entry point ─────────────────────────────────────────────────────────
+
+/**
+ * Run one agent turn for `workspaceId` given a user `prompt`.
+ *
+ * Streams token deltas to the agent bus as `thinking` events, emits
+ * `tool_call` / `tool_result` pairs around every tool invocation, and
+ * finalises with a `message` + `inference_receipt` + `done` triple.
+ *
+ * Never throws — all errors are swallowed and forwarded to the bus as
+ * `error` + `done` events so the frontend always gets a terminal frame.
+ */
+export async function runAgentTurn(
+  workspaceId: string,
+  prompt: string,
+  config: AgentConfig,
+  adapter: AgentAdapter,
+): Promise<void> {
+  const streamId = StreamIdSchema.parse(workspaceId);
+
+  const baseEvent = (): { streamId: typeof streamId; seq: number; emittedAt: number } => ({
+    streamId,
+    seq: adapter.nextSeq(workspaceId),
+    emittedAt: Date.now(),
+  });
+
+  const emit = (event: AgentEvent): void => adapter.publishEvent(workspaceId, event);
+
+  // Echo the user's prompt so the chat rail shows it.
+  emit({ ...baseEvent(), type: 'message', content: `**you:** ${prompt}` });
+
+  // Collect workspace files for the system prompt.  Non-fatal if the
+  // workspace directory doesn't exist yet.
+  let files: WorkspaceFile[] = [];
+  try {
+    files = await adapter.getWorkspaceFiles(workspaceId);
+  } catch {
+    // Proceed without file context.
+  }
+
+  const openai = createOpenAI({
+    baseURL: config.baseUrl,
+    apiKey: config.apiKey,
+    ...(config.headers ? { headers: config.headers } : {}),
+  });
+
+  let promptTokens = 0;
+  let completionTokens = 0;
+  let fullResponse = '';
+
+  try {
+    const result = streamText({
+      model: openai(config.model),
+      system: buildSystemPrompt(files),
+      messages: [{ role: 'user', content: prompt }],
+      stopWhen: stepCountIs(20),
+      maxRetries: 1,
+      tools: {
+        // ── read_file ──────────────────────────────────────────────────────
+        read_file: tool({
+          description:
+            'Read the content of a file in the workspace. Use the workspace-relative path.',
+          inputSchema: z.object({
+            path: z
+              .string()
+              .min(1)
+              .describe('Workspace-relative file path, e.g. "contracts/Lock.sol"'),
+          }),
+          execute: async ({ path: filePath }) => {
+            try {
+              const fresh = await adapter.getWorkspaceFiles(workspaceId);
+              const file = fresh.find((f) => f.path === filePath);
+              if (!file) return { ok: false as const, error: `File not found: ${filePath}` };
+              return { ok: true as const, content: file.content ?? '' };
+            } catch (err) {
+              return {
+                ok: false as const,
+                error: err instanceof Error ? err.message : String(err),
+              };
+            }
+          },
+        }),
+
+        // ── write_file ─────────────────────────────────────────────────────
+        write_file: tool({
+          description: 'Write or overwrite a file in the workspace.',
+          inputSchema: z.object({
+            path: z
+              .string()
+              .min(1)
+              .describe('Workspace-relative file path, e.g. "contracts/Lock.sol"'),
+            content: z.string().describe('Complete file content to write'),
+          }),
+          execute: async ({ path: filePath, content }) => {
+            try {
+              const wf = await adapter.writeFile(workspaceId, filePath, content);
+              emit({
+                ...baseEvent(),
+                type: 'file_write',
+                path: wf.path,
+                lang: wf.lang,
+                hash: wf.hash,
+                content: wf.content,
+              });
+              return { ok: true as const, path: wf.path, hash: wf.hash };
+            } catch (err) {
+              return {
+                ok: false as const,
+                error: err instanceof Error ? err.message : String(err),
+              };
+            }
+          },
+        }),
+
+        // ── run_shell ──────────────────────────────────────────────────────
+        run_shell: tool({
+          description:
+            'Run a shell command in the workspace directory. ' +
+            'Returns stdout, stderr, and exitCode. ' +
+            'Use bun for package management; npx hardhat or forge for contracts.',
+          inputSchema: z.object({
+            cmd: z.string().min(1).describe('Shell command to execute'),
+          }),
+          execute: async ({ cmd }) => {
+            try {
+              return await adapter.runShell(workspaceId, cmd);
+            } catch (err) {
+              return {
+                stdout: '',
+                stderr: err instanceof Error ? err.message : String(err),
+                exitCode: 1,
+              };
+            }
+          },
+        }),
+
+        // ── mcp_tool ───────────────────────────────────────────────────────
+        mcp_tool: tool({
+          description:
+            'Call a tool on one of the workspace MCP microservices. ' +
+            'Servers: chain (Hardhat fork), compiler, deployer, wallet, memory.',
+          inputSchema: z.object({
+            server: z
+              .enum(['chain', 'compiler', 'deployer', 'wallet', 'memory'])
+              .describe('MCP server to call'),
+            tool: z.string().min(1).describe('Tool name on that server'),
+            args: z.record(z.string(), z.unknown()).describe('Tool arguments as a JSON object'),
+          }),
+          execute: async ({ server, tool: toolName, args }) => {
+            const callId = CallIdSchema.parse(crypto.randomUUID());
+            emit({
+              ...baseEvent(),
+              type: 'tool_call',
+              callId,
+              tool: `${server}.${toolName}`,
+              args,
+            });
+            try {
+              const result = await adapter.executeMcpTool(workspaceId, server, toolName, args);
+              emit({
+                ...baseEvent(),
+                type: 'tool_result',
+                callId,
+                outcome: { ok: true, result },
+              });
+              return result;
+            } catch (err) {
+              const error = err instanceof Error ? err.message : String(err);
+              emit({
+                ...baseEvent(),
+                type: 'tool_result',
+                callId,
+                outcome: { ok: false, error },
+              });
+              return { error };
+            }
+          },
+        }),
+      },
+    });
+
+    for await (const chunk of result.fullStream) {
+      switch (chunk.type) {
+        case 'text-delta':
+          fullResponse += chunk.text;
+          emit({ ...baseEvent(), type: 'thinking', text: chunk.text });
+          break;
+
+        case 'finish':
+          promptTokens = chunk.totalUsage.inputTokens ?? 0;
+          completionTokens = chunk.totalUsage.outputTokens ?? 0;
+          break;
+
+        case 'error':
+          emit({
+            ...baseEvent(),
+            type: 'error',
+            message: chunk.error instanceof Error ? chunk.error.message : String(chunk.error),
+          });
+          break;
+
+        default:
+          // tool-call / tool-result / step events are handled inside each
+          // tool's execute function above; we don't need to re-process them.
+          break;
+      }
+    }
+  } catch (err) {
+    emit({
+      ...baseEvent(),
+      type: 'error',
+      message: `Agent loop failed: ${err instanceof Error ? err.message : String(err)}`,
+    });
+    emit({ ...baseEvent(), type: 'done' });
+    return;
+  }
+
+  // Emit consolidated assistant reply.
+  if (fullResponse.trim().length > 0) {
+    emit({ ...baseEvent(), type: 'message', content: fullResponse });
+  }
+
+  // Emit inference receipt so the frontend can display cost / provenance.
+  emit({
+    ...baseEvent(),
+    type: 'inference_receipt',
+    receipt: {
+      id: InferenceReceiptIdSchema.parse(crypto.randomUUID()),
+      provider: config.provider ?? 'openai-compatible',
+      model: config.model,
+      attestation: null,
+      fallbackReason: config.provider === '0g-compute' ? null : 'admin_override',
+      promptTokens,
+      completionTokens,
+      createdAt: Date.now(),
+    },
+  });
+
+  emit({ ...baseEvent(), type: 'done' });
+}

--- a/packages/agent/src/loop.ts
+++ b/packages/agent/src/loop.ts
@@ -142,7 +142,11 @@ export async function runAgentTurn(
 
   try {
     const result = streamText({
-      model: openai(config.model),
+      // Use .chat() to target /v1/chat/completions (standard SSE format).
+      // The default callable routes to the Responses API (/v1/responses) which
+      // uses text-start/text-delta/text-end — a format most compatible
+      // providers don't implement, causing "text part not found" errors.
+      model: openai.chat(config.model),
       system: buildSystemPrompt(files),
       messages: [{ role: 'user', content: prompt }],
       stopWhen: stepCountIs(20),

--- a/packages/agent/src/loop.ts
+++ b/packages/agent/src/loop.ts
@@ -13,14 +13,17 @@
 
 import { streamText, tool, stepCountIs } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
+import { createMCPClient, type MCPClient } from '@ai-sdk/mcp';
 import { z } from 'zod';
 import {
   CallIdSchema,
   InferenceReceiptIdSchema,
   StreamIdSchema,
   type AgentEvent,
+  type CallId,
   type FallbackReason,
   type WorkspaceFile,
+  mcp,
 } from '@crucible/types';
 import { buildSystemPrompt } from './system-prompt.ts';
 
@@ -47,6 +50,14 @@ export interface AgentConfig {
    * in the inference_receipt event so the UI can show honest fallback state.
    */
   fallbackReason?: FallbackReason | null;
+  /**
+   * Per-server MCP endpoint URLs for the workspace container.
+   * Key is the logical server name; value is the full MCP transport URL
+   * (e.g. `http://127.0.0.1:32768/mcp`).
+   * When present, the agent connects to that server directly via the AI SDK
+   * MCP client rather than routing through the REST proxy in tool-exec.ts.
+   */
+  mcpServerUrls?: Partial<Record<'chain' | 'compiler' | 'deployer' | 'wallet' | 'memory', string>>;
 }
 
 /** Shell execution result returned by adapter.runShell. */
@@ -75,19 +86,58 @@ export interface AgentAdapter {
   /** Run `cmd` in a shell scoped to the workspace directory. */
   runShell(workspaceId: string, cmd: string): Promise<ShellResult>;
 
-  /** Proxy a tool call to one of the workspace's MCP microservices. */
-  executeMcpTool(
-    workspaceId: string,
-    server: string,
-    toolName: string,
-    args: Record<string, unknown>,
-  ): Promise<unknown>;
-
   /** Publish an event to the agent bus for this workspace. */
   publishEvent(workspaceId: string, event: AgentEvent): void;
 
   /** Allocate the next monotonic sequence number for this workspace's stream. */
   nextSeq(workspaceId: string): number;
+}
+
+// ── MCP schema registry ──────────────────────────────────────────────────────
+
+type McpServerKey = 'chain' | 'compiler' | 'deployer' | 'wallet' | 'memory';
+
+function getMcpSchemas(server: McpServerKey) {
+  switch (server) {
+    case 'chain':
+      return {
+        start_node: { inputSchema: mcp.chain.StartNodeInputSchema },
+        get_state: { inputSchema: mcp.chain.GetStateInputSchema },
+        snapshot: { inputSchema: mcp.chain.SnapshotInputSchema },
+        revert: { inputSchema: mcp.chain.RevertInputSchema },
+        mine: { inputSchema: mcp.chain.MineInputSchema },
+        fork: { inputSchema: mcp.chain.ForkInputSchema },
+      };
+    case 'compiler':
+      return {
+        compile: { inputSchema: mcp.compiler.CompileInputSchema },
+        list_contracts: { inputSchema: mcp.compiler.ListContractsInputSchema },
+        get_abi: { inputSchema: mcp.compiler.GetAbiInputSchema },
+        get_bytecode: { inputSchema: mcp.compiler.GetBytecodeInputSchema },
+      };
+    case 'deployer':
+      return {
+        deploy_local: { inputSchema: mcp.deployer.DeployLocalInputSchema },
+        simulate_local: { inputSchema: mcp.deployer.SimulateLocalInputSchema },
+        trace: { inputSchema: mcp.deployer.TraceInputSchema },
+        call: { inputSchema: mcp.deployer.CallInputSchema },
+      };
+    case 'wallet':
+      return {
+        list_accounts: { inputSchema: mcp.wallet.ListAccountsInputSchema },
+        get_balance: { inputSchema: mcp.wallet.GetBalanceInputSchema },
+        sign_tx: { inputSchema: mcp.wallet.SignTxInputSchema },
+        send_tx_local: { inputSchema: mcp.wallet.SendTxLocalInputSchema },
+        switch_account: { inputSchema: mcp.wallet.SwitchAccountInputSchema },
+      };
+    case 'memory':
+      return {
+        recall: { inputSchema: mcp.memory.RecallInputSchema },
+        remember: { inputSchema: mcp.memory.RememberInputSchema },
+        list_patterns: { inputSchema: mcp.memory.ListPatternsInputSchema },
+        provenance: { inputSchema: mcp.memory.ProvenanceInputSchema },
+      };
+  }
 }
 
 // ── Main entry point ─────────────────────────────────────────────────────────
@@ -139,6 +189,33 @@ export async function runAgentTurn(
   let promptTokens = 0;
   let completionTokens = 0;
   let fullResponse = '';
+
+  // ── MCP client setup ───────────────────────────────────────────────────────
+  const mcpClients: MCPClient[] = [];
+  const mcpToolNames = new Set<string>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mcpToolsObj: Record<string, any> = {};
+  for (const [serverName, url] of Object.entries(config.mcpServerUrls ?? {})) {
+    if (!url) continue;
+    try {
+      const client = await createMCPClient({ transport: { type: 'http', url } });
+      mcpClients.push(client);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const serverTools = await client.tools({
+        schemas: getMcpSchemas(serverName as McpServerKey) as any,
+      });
+      for (const name of Object.keys(serverTools)) mcpToolNames.add(name);
+      Object.assign(mcpToolsObj, serverTools);
+    } catch (err) {
+      console.warn(
+        `[agent] MCP client init failed for ${serverName}:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  // toolCallId → AgentEvent callId — links tool_call and tool_result events.
+  const pendingMcpCalls = new Map<string, CallId>();
 
   try {
     const result = streamText({
@@ -230,48 +307,8 @@ export async function runAgentTurn(
           },
         }),
 
-        // ── mcp_tool ───────────────────────────────────────────────────────
-        mcp_tool: tool({
-          description:
-            'Call a tool on one of the workspace MCP microservices. ' +
-            'Servers: chain (Hardhat fork), compiler, deployer, wallet, memory.',
-          inputSchema: z.object({
-            server: z
-              .enum(['chain', 'compiler', 'deployer', 'wallet', 'memory'])
-              .describe('MCP server to call'),
-            tool: z.string().min(1).describe('Tool name on that server'),
-            args: z.record(z.string(), z.unknown()).describe('Tool arguments as a JSON object'),
-          }),
-          execute: async ({ server, tool: toolName, args }) => {
-            const callId = CallIdSchema.parse(crypto.randomUUID());
-            emit({
-              ...baseEvent(),
-              type: 'tool_call',
-              callId,
-              tool: `${server}.${toolName}`,
-              args,
-            });
-            try {
-              const result = await adapter.executeMcpTool(workspaceId, server, toolName, args);
-              emit({
-                ...baseEvent(),
-                type: 'tool_result',
-                callId,
-                outcome: { ok: true, result },
-              });
-              return result;
-            } catch (err) {
-              const error = err instanceof Error ? err.message : String(err);
-              emit({
-                ...baseEvent(),
-                type: 'tool_result',
-                callId,
-                outcome: { ok: false, error },
-              });
-              return { error };
-            }
-          },
-        }),
+        // ── MCP tools (connected directly via @ai-sdk/mcp) ────────────────
+        ...mcpToolsObj,
       },
     });
 
@@ -287,6 +324,53 @@ export async function runAgentTurn(
           completionTokens = chunk.totalUsage.outputTokens ?? 0;
           break;
 
+        case 'tool-call':
+          if (mcpToolNames.has(chunk.toolName)) {
+            const callId = CallIdSchema.parse(crypto.randomUUID());
+            pendingMcpCalls.set(chunk.toolCallId, callId);
+            emit({
+              ...baseEvent(),
+              type: 'tool_call',
+              callId,
+              tool: chunk.toolName,
+              args: chunk.input as Record<string, unknown>,
+            });
+          }
+          break;
+
+        case 'tool-result':
+          if (mcpToolNames.has(chunk.toolName)) {
+            const callId = pendingMcpCalls.get(chunk.toolCallId);
+            if (callId) {
+              pendingMcpCalls.delete(chunk.toolCallId);
+              const raw = chunk.output as {
+                isError?: boolean;
+                content?: Array<{ type: string; text?: string }>;
+              };
+              if (raw.isError) {
+                const error =
+                  raw.content
+                    ?.filter((c) => c.type === 'text')
+                    .map((c) => c.text ?? '')
+                    .join('\n') ?? 'MCP tool error';
+                emit({
+                  ...baseEvent(),
+                  type: 'tool_result',
+                  callId,
+                  outcome: { ok: false, error },
+                });
+              } else {
+                emit({
+                  ...baseEvent(),
+                  type: 'tool_result',
+                  callId,
+                  outcome: { ok: true, result: raw },
+                });
+              }
+            }
+          }
+          break;
+
         case 'error':
           emit({
             ...baseEvent(),
@@ -296,8 +380,6 @@ export async function runAgentTurn(
           break;
 
         default:
-          // tool-call / tool-result / step events are handled inside each
-          // tool's execute function above; we don't need to re-process them.
           break;
       }
     }
@@ -309,6 +391,8 @@ export async function runAgentTurn(
     });
     emit({ ...baseEvent(), type: 'done' });
     return;
+  } finally {
+    await Promise.all(mcpClients.map((c) => c.close().catch(() => undefined)));
   }
 
   // Emit consolidated assistant reply.

--- a/packages/agent/src/loop.ts
+++ b/packages/agent/src/loop.ts
@@ -97,7 +97,7 @@ export interface AgentAdapter {
 
 type McpServerKey = 'chain' | 'compiler' | 'deployer' | 'wallet' | 'memory';
 
-function getMcpSchemas(server: McpServerKey) {
+function getMcpSchemas(server: McpServerKey): Record<string, { inputSchema: z.ZodTypeAny }> {
   switch (server) {
     case 'chain':
       return {
@@ -194,15 +194,14 @@ export async function runAgentTurn(
   const mcpClients: MCPClient[] = [];
   const mcpToolNames = new Set<string>();
   const toolToServer = new Map<string, string>(); // toolName → serverName for event emission
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const mcpToolsObj: Record<string, any> = {};
+  const mcpToolsObj: Awaited<ReturnType<MCPClient['tools']>> = {};
   for (const [serverName, url] of Object.entries(config.mcpServerUrls ?? {})) {
     if (!url) continue;
     try {
       const client = await createMCPClient({ transport: { type: 'http', url } });
       mcpClients.push(client);
       const serverTools = await client.tools({
-        schemas: getMcpSchemas(serverName as McpServerKey) as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+        schemas: getMcpSchemas(serverName as McpServerKey),
       });
       for (const name of Object.keys(serverTools)) {
         mcpToolNames.add(name);

--- a/packages/agent/src/system-prompt.ts
+++ b/packages/agent/src/system-prompt.ts
@@ -62,8 +62,8 @@ frontend/      — React + Vite + wagmi/viem dApp
 ## Workflow guidelines
 
 1. **Read before writing.** Use read_file to inspect a file before overwriting it.
-2. **Compile early.** After editing a .sol file call mcp_tool chain compiler/compile.
-3. **Incremental deploys.** Use deployer.deploy after a successful compile.
+2. **Compile early.** After editing a .sol file call mcp_tool with server "compiler" and tool "compile".
+3. **Incremental deploys.** Use mcp_tool with server "deployer" and tool "deploy" after a successful compile.
 4. **Update the frontend.** After deploying, update frontend/src/App.tsx with the
    new contract address and ABI from the deployer result.
 5. **Use wagmi/viem idioms** in the frontend — useReadContract, useWriteContract.

--- a/packages/agent/src/system-prompt.ts
+++ b/packages/agent/src/system-prompt.ts
@@ -35,52 +35,38 @@ wagmi/viem React frontend.
   root). Prefer \`bun\` for package management, \`npx hardhat\` or \`forge\` for
   contract tooling. Stdout + stderr are returned; exitCode 0 means success.
 
-### MCP runtime tools (use mcp_tool)
-Each of the following services runs inside the workspace's Docker container.
-Call them via the \`mcp_tool\` tool with the correct \`server\` and \`args\` values.
+### MCP runtime tools — call these directly by name
+Each tool is a first-class function with a strict input schema; the SDK enforces
+required arguments at the protocol level. **Always prefer these tools over
+\`run_shell hardhat …\`** — the MCP services share the workspace's running
+Hardhat node, while shell-spawned hardhat would start its own ephemeral chain
+and you would lose all deployed state.
 
-**chain** — Hardhat local fork
-| tool        | required args                          |
-|-------------|----------------------------------------|
-| start_node  | (none)                                 |
-| get_state   | (none)                                 |
-| snapshot    | (none)                                 |
-| revert      | \`{ snapshotId: string }\`             |
-| mine        | \`{ blocks?: number }\`               |
-| fork        | \`{ rpcUrl: string, blockNumber?: number }\` |
+**chain** — workspace Hardhat node
+- \`start_node()\` — start the node (required before any deploy or RPC call)
+- \`get_state()\` — chainId, blockNumber, gasPrice, accounts
+- \`snapshot()\` → returns \`{ snapshotId }\`
+- \`revert({ snapshotId })\`
 
-**compiler** — Solidity compilation (Hardhat)
-| tool            | required args                                                     |
-|-----------------|-------------------------------------------------------------------|
-| compile         | \`{ sourcePath: "contracts/MyContract.sol" }\` — workspace-relative path |
-| list_contracts  | (none) — returns names of all compiled contracts                  |
-| get_abi         | \`{ contractName: "Counter" }\`                                   |
-| get_bytecode    | \`{ contractName: "Counter" }\`                                   |
+**compiler** — Hardhat-driven Solidity compilation
+- \`compile({ sourcePath: "contracts/Counter.sol" })\` — sourcePath is required
+- \`list_contracts()\`
+- \`get_abi({ contractName: "Counter" })\`
+- \`get_bytecode({ contractName: "Counter" })\`
 
-**deployer** — local-chain deploy and trace (no public-chain access)
-| tool           | required args                                                                              |
-|----------------|--------------------------------------------------------------------------------------------|
-| deploy_local   | \`{ contractName: "Counter", constructorData: "0x" }\` — compile first, then deploy by name |
-| simulate_local | \`{ tx: { from?, to, data, value?, gas? } }\`                                              |
-| trace          | \`{ txHash: "0x..." }\`                                                                    |
-| call           | \`{ tx: { from?, to, data } }\`                                                            |
+**deployer** — local-chain deploy and trace (no public chain)
+- \`deploy_local({ contractName: "Counter", constructorData: "0x" })\`
+- \`simulate_local({ tx: { to, data, from? } })\`
+- \`trace({ txHash })\`
 
-**wallet** — embedded dev wallet (Hardhat test accounts)
-| tool           | required args                   |
-|----------------|---------------------------------|
-| list_accounts  | (none)                          |
-| get_balance    | \`{ address: "0x..." }\`        |
-| sign_tx        | \`{ tx: { ... } }\`            |
-| send_tx_local  | \`{ signedTx: "0x..." }\`       |
-| switch_account | \`{ address: "0x..." }\`        |
+**wallet** — embedded dev wallet
+- \`list_accounts()\`
+- \`get_balance({ address })\`
+- \`send_tx_local({ tx: { from, to, data, chainId } })\`
 
-**memory** — pattern / knowledge store
-| tool          | required args                                      |
-|---------------|----------------------------------------------------|
-| recall        | \`{ revertSignature?: string, freeform?: string }\` |
-| remember      | \`{ pattern: { ... } }\`                            |
-| list_patterns | (none)                                             |
-| provenance    | \`{ id: "pattern-id" }\`                            |
+**memory** — pattern store
+- \`recall({ revertSignature?, freeform? })\` — at least one field required
+- \`list_patterns()\`
 
 ## Workspace layout
 
@@ -97,8 +83,8 @@ frontend/      — React + Vite + wagmi/viem dApp
 ## Workflow guidelines
 
 1. **Read before writing.** Use read_file to inspect a file before overwriting it.
-2. **Compile early.** After editing a .sol file call mcp_tool with server "compiler", tool "compile", and args \`{ sourcePath: "contracts/MyContract.sol" }\`.
-3. **Incremental deploys.** After a successful compile, call mcp_tool with server "deployer", tool "deploy_local", and args \`{ contractName: "MyContract", constructorData: "0x" }\`.
+2. **Compile early.** After editing a .sol file call \`compile({ sourcePath: "contracts/MyContract.sol" })\`.
+3. **Incremental deploys.** After a successful compile call \`deploy_local({ contractName: "MyContract", constructorData: "0x" })\`.
 4. **Update the frontend.** After deploying, update frontend/src/App.tsx with the
    new contract address and ABI from the deployer result.
 5. **Use wagmi/viem idioms** in the frontend — useReadContract, useWriteContract.

--- a/packages/agent/src/system-prompt.ts
+++ b/packages/agent/src/system-prompt.ts
@@ -37,15 +37,50 @@ wagmi/viem React frontend.
 
 ### MCP runtime tools (use mcp_tool)
 Each of the following services runs inside the workspace's Docker container.
-Call them via the \`mcp_tool\` tool with the correct \`server\` value.
+Call them via the \`mcp_tool\` tool with the correct \`server\` and \`args\` values.
 
-| server   | purpose                                  | key tools                              |
-|----------|------------------------------------------|----------------------------------------|
-| chain    | Hardhat local fork (JSON-RPC)            | start_node, get_state, snapshot, revert, mine, fork |
-| compiler | Solidity compilation via hardhat/foundry | compile, list_contracts, get_abi, get_bytecode |
-| deployer | Contract deployment + verification       | deploy, verify                         |
-| wallet   | In-workspace key management              | get_balance, send                      |
-| memory   | Pattern / knowledge store                | get, set                               |
+**chain** — Hardhat local fork
+| tool        | required args                          |
+|-------------|----------------------------------------|
+| start_node  | (none)                                 |
+| get_state   | (none)                                 |
+| snapshot    | (none)                                 |
+| revert      | \`{ snapshotId: string }\`             |
+| mine        | \`{ blocks?: number }\`               |
+| fork        | \`{ rpcUrl: string, blockNumber?: number }\` |
+
+**compiler** — Solidity compilation (Hardhat)
+| tool            | required args                                                     |
+|-----------------|-------------------------------------------------------------------|
+| compile         | \`{ sourcePath: "contracts/MyContract.sol" }\` — workspace-relative path |
+| list_contracts  | (none) — returns names of all compiled contracts                  |
+| get_abi         | \`{ contractName: "Counter" }\`                                   |
+| get_bytecode    | \`{ contractName: "Counter" }\`                                   |
+
+**deployer** — local-chain deploy and trace (no public-chain access)
+| tool           | required args                                                                              |
+|----------------|--------------------------------------------------------------------------------------------|
+| deploy_local   | \`{ contractName: "Counter", constructorData: "0x" }\` — compile first, then deploy by name |
+| simulate_local | \`{ tx: { from?, to, data, value?, gas? } }\`                                              |
+| trace          | \`{ txHash: "0x..." }\`                                                                    |
+| call           | \`{ tx: { from?, to, data } }\`                                                            |
+
+**wallet** — embedded dev wallet (Hardhat test accounts)
+| tool           | required args                   |
+|----------------|---------------------------------|
+| list_accounts  | (none)                          |
+| get_balance    | \`{ address: "0x..." }\`        |
+| sign_tx        | \`{ tx: { ... } }\`            |
+| send_tx_local  | \`{ signedTx: "0x..." }\`       |
+| switch_account | \`{ address: "0x..." }\`        |
+
+**memory** — pattern / knowledge store
+| tool          | required args                                      |
+|---------------|----------------------------------------------------|
+| recall        | \`{ revertSignature?: string, freeform?: string }\` |
+| remember      | \`{ pattern: { ... } }\`                            |
+| list_patterns | (none)                                             |
+| provenance    | \`{ id: "pattern-id" }\`                            |
 
 ## Workspace layout
 
@@ -62,8 +97,8 @@ frontend/      — React + Vite + wagmi/viem dApp
 ## Workflow guidelines
 
 1. **Read before writing.** Use read_file to inspect a file before overwriting it.
-2. **Compile early.** After editing a .sol file call mcp_tool with server "compiler" and tool "compile".
-3. **Incremental deploys.** Use mcp_tool with server "deployer" and tool "deploy" after a successful compile.
+2. **Compile early.** After editing a .sol file call mcp_tool with server "compiler", tool "compile", and args \`{ sourcePath: "contracts/MyContract.sol" }\`.
+3. **Incremental deploys.** After a successful compile, call mcp_tool with server "deployer", tool "deploy_local", and args \`{ contractName: "MyContract", constructorData: "0x" }\`.
 4. **Update the frontend.** After deploying, update frontend/src/App.tsx with the
    new contract address and ABI from the deployer result.
 5. **Use wagmi/viem idioms** in the frontend — useReadContract, useWriteContract.

--- a/packages/agent/src/system-prompt.ts
+++ b/packages/agent/src/system-prompt.ts
@@ -1,0 +1,76 @@
+/**
+ * Builds the system prompt for the Crucible agent.
+ *
+ * The prompt is personalised with the current workspace files so the model
+ * starts each turn with accurate context about what has already been written.
+ */
+
+import type { WorkspaceFile } from '@crucible/types';
+
+/**
+ * Build a system prompt that gives the model its role, capability set, and a
+ * summarised view of the current workspace so it doesn't have to call
+ * `read_file` for every file on every turn.
+ */
+export function buildSystemPrompt(files: WorkspaceFile[]): string {
+  const fileIndex =
+    files.length === 0
+      ? '(empty — no files yet)'
+      : files.map((f) => `  • ${f.path}  [${f.lang}]  sha256:${f.hash.slice(0, 8)}`).join('\n');
+
+  return `\
+You are Crucible, an autonomous smart-contract development agent running inside
+a browser-based IDE. Your goal is to help the user write, compile, deploy, and
+verify Solidity contracts on a local Hardhat fork and ship a corresponding
+wagmi/viem React frontend.
+
+## Your capabilities
+
+### File operations
+- read_file  — read any workspace file by its relative path
+- write_file — write or overwrite a workspace file
+
+### Shell
+- run_shell — execute a shell command in the workspace directory (cwd = workspace
+  root). Prefer \`bun\` for package management, \`npx hardhat\` or \`forge\` for
+  contract tooling. Stdout + stderr are returned; exitCode 0 means success.
+
+### MCP runtime tools (use mcp_tool)
+Each of the following services runs inside the workspace's Docker container.
+Call them via the \`mcp_tool\` tool with the correct \`server\` value.
+
+| server   | purpose                                  | key tools                              |
+|----------|------------------------------------------|----------------------------------------|
+| chain    | Hardhat local fork (JSON-RPC)            | start_node, get_state, snapshot, revert, mine, fork |
+| compiler | Solidity compilation via hardhat/foundry | compile, list_contracts, get_abi, get_bytecode |
+| deployer | Contract deployment + verification       | deploy, verify                         |
+| wallet   | In-workspace key management              | get_balance, send                      |
+| memory   | Pattern / knowledge store                | get, set                               |
+
+## Workspace layout
+
+\`\`\`
+contracts/     — Solidity source files (.sol)
+frontend/      — React + Vite + wagmi/viem dApp
+  src/
+    main.tsx
+    App.tsx
+    config.ts  — wagmi chain / connector config
+.crucible/     — workspace metadata (do not edit)
+\`\`\`
+
+## Workflow guidelines
+
+1. **Read before writing.** Use read_file to inspect a file before overwriting it.
+2. **Compile early.** After editing a .sol file call mcp_tool chain compiler/compile.
+3. **Incremental deploys.** Use deployer.deploy after a successful compile.
+4. **Update the frontend.** After deploying, update frontend/src/App.tsx with the
+   new contract address and ABI from the deployer result.
+5. **Use wagmi/viem idioms** in the frontend — useReadContract, useWriteContract.
+6. **Be concise** in your thinking text. The user reads every token.
+
+## Current workspace files
+
+${fileIndex}
+`;
+}

--- a/packages/agent/test/system-prompt.test.ts
+++ b/packages/agent/test/system-prompt.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test';
+import { buildSystemPrompt } from '../src/system-prompt.ts';
+
+describe('buildSystemPrompt', () => {
+  test('includes empty-workspace placeholder when no files', () => {
+    const prompt = buildSystemPrompt([]);
+    expect(prompt).toContain('(empty — no files yet)');
+  });
+
+  test('lists each file path, lang, and hash prefix', () => {
+    const now = Date.now();
+    const prompt = buildSystemPrompt([
+      {
+        path: 'contracts/Vault.sol',
+        lang: 'solidity',
+        hash: 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+        content: '',
+        modifiedAt: now,
+      },
+      {
+        path: 'frontend/src/App.tsx',
+        lang: 'tsx',
+        hash: 'deadbeef00000000deadbeef00000000deadbeef00000000deadbeef00000000',
+        content: '',
+        modifiedAt: now,
+      },
+    ]);
+    expect(prompt).toContain('contracts/Vault.sol');
+    expect(prompt).toContain('[solidity]');
+    expect(prompt).toContain('sha256:abcdef12');
+    expect(prompt).toContain('frontend/src/App.tsx');
+    expect(prompt).toContain('[tsx]');
+    expect(prompt).toContain('sha256:deadbeef');
+  });
+
+  test('includes expected capability sections', () => {
+    const prompt = buildSystemPrompt([]);
+    expect(prompt).toContain('read_file');
+    expect(prompt).toContain('write_file');
+    expect(prompt).toContain('run_shell');
+    expect(prompt).toContain('mcp_tool');
+  });
+});

--- a/packages/agent/test/system-prompt.test.ts
+++ b/packages/agent/test/system-prompt.test.ts
@@ -38,6 +38,7 @@ describe('buildSystemPrompt', () => {
     expect(prompt).toContain('read_file');
     expect(prompt).toContain('write_file');
     expect(prompt).toContain('run_shell');
-    expect(prompt).toContain('mcp_tool');
+    expect(prompt).toContain('compile');
+    expect(prompt).toContain('deploy_local');
   });
 });

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "composite": true,
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,6 +21,8 @@
     "runtime:build": "docker build -t ${CRUCIBLE_RUNTIME_IMAGE:-crucible-runtime:latest} -f runtime/Dockerfile ../.."
   },
   "dependencies": {
+    "@0glabs/0g-serving-broker": "^0.7.5",
+    "@crucible/agent": "workspace:*",
     "@crucible/types": "workspace:*",
     "@hono/zod-openapi": "^1.3.0",
     "@prisma/adapter-pg": "^7.8.0",
@@ -28,7 +30,9 @@
     "better-auth": "^1.6.9",
     "dockerode": "^4.0.9",
     "dotenv": "^17.4.2",
+    "ethers": "^6.13.0",
     "hono": "^4.12.15",
+    "node-pty": "^1.1.0",
     "pg": "^8.20.0",
     "zod": "^4.0.0"
   },

--- a/packages/backend/prisma/migrations/20260427000000_add_workspace_user_id/migration.sql
+++ b/packages/backend/prisma/migrations/20260427000000_add_workspace_user_id/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable: add required userId FK to workspace
+ALTER TABLE "workspace" ADD COLUMN "userId" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "workspace_userId_idx" ON "workspace"("userId");
+
+-- AddForeignKey
+ALTER TABLE "workspace" ADD CONSTRAINT "workspace_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/backend/prisma/models/workspace.prisma
+++ b/packages/backend/prisma/models/workspace.prisma
@@ -13,8 +13,8 @@ model Workspace {
     createdAt     DateTime          @default(now())
     updatedAt     DateTime          @updatedAt
     deployments   Json              @default("[]")
-    userId        String?
-    user          User?             @relation(fields: [userId], references: [id], onDelete: SetNull)
+    userId        String
+    user          User              @relation(fields: [userId], references: [id], onDelete: Cascade)
     runtime       WorkspaceRuntime?
 
     @@index([userId])

--- a/packages/backend/prisma/models/workspace.prisma
+++ b/packages/backend/prisma/models/workspace.prisma
@@ -13,8 +13,11 @@ model Workspace {
     createdAt     DateTime          @default(now())
     updatedAt     DateTime          @updatedAt
     deployments   Json              @default("[]")
+    userId        String?
+    user          User?             @relation(fields: [userId], references: [id], onDelete: SetNull)
     runtime       WorkspaceRuntime?
 
+    @@index([userId])
     @@map("workspace")
 }
 

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -14,10 +14,11 @@ model User {
   emailVerified Boolean   @default(false)
   image         String?
   isAnonymous   Boolean?  @default(false)
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
   sessions      Session[]
   accounts      Account[]
+  workspaces    Workspace[]
 
   @@unique([email])
   @@map("user")

--- a/packages/backend/runtime/Dockerfile
+++ b/packages/backend/runtime/Dockerfile
@@ -26,6 +26,9 @@ COPY tsconfig.base.json ./
 COPY packages/types/package.json packages/types/
 COPY packages/mcp-chain/package.json packages/mcp-chain/
 COPY packages/mcp-compiler/package.json packages/mcp-compiler/
+COPY packages/mcp-deployer/package.json packages/mcp-deployer/
+COPY packages/mcp-wallet/package.json packages/mcp-wallet/
+COPY packages/mcp-memory/package.json packages/mcp-memory/
 
 RUN bun install --frozen-lockfile || bun install
 
@@ -33,6 +36,9 @@ RUN bun install --frozen-lockfile || bun install
 COPY packages/types ./packages/types
 COPY packages/mcp-chain ./packages/mcp-chain
 COPY packages/mcp-compiler ./packages/mcp-compiler
+COPY packages/mcp-deployer ./packages/mcp-deployer
+COPY packages/mcp-wallet ./packages/mcp-wallet
+COPY packages/mcp-memory ./packages/mcp-memory
 
 # /workspace is the per-workspace bind mount target.
 WORKDIR /workspace

--- a/packages/backend/runtime/Dockerfile
+++ b/packages/backend/runtime/Dockerfile
@@ -42,10 +42,14 @@ WORKDIR /workspace
 # both servers is widened via ALLOWED_HOSTS.
 ENV CHAIN_MCP_PORT=3100 \
     COMPILER_MCP_PORT=3101 \
+    DEPLOYER_MCP_PORT=3102 \
+    WALLET_MCP_PORT=3103 \
+    MEMORY_MCP_PORT=3104 \
+    TERMINAL_MCP_PORT=3105 \
     WORKSPACE_ROOT=/workspace \
     ALLOWED_HOSTS=host.docker.internal
 
-EXPOSE 3100 3101
+EXPOSE 3100 3101 3102 3103 3104 3105
 
 COPY packages/backend/runtime/entrypoint.sh /usr/local/bin/crucible-runtime-entrypoint
 RUN chmod +x /usr/local/bin/crucible-runtime-entrypoint

--- a/packages/backend/runtime/entrypoint.sh
+++ b/packages/backend/runtime/entrypoint.sh
@@ -25,27 +25,38 @@ log "starting mcp-compiler on port ${COMPILER_MCP_PORT}"
 bun run --cwd /app/packages/mcp-compiler start &
 compiler_pid=$!
 
+log "starting mcp-deployer on port ${DEPLOYER_MCP_PORT}"
+bun run --cwd /app/packages/mcp-deployer start &
+deployer_pid=$!
+
+log "starting mcp-wallet on port ${WALLET_MCP_PORT}"
+bun run --cwd /app/packages/mcp-wallet start &
+wallet_pid=$!
+
+log "starting mcp-memory on port ${MEMORY_MCP_PORT}"
+bun run --cwd /app/packages/mcp-memory start &
+memory_pid=$!
+
 shutdown() {
     log "received shutdown — terminating services"
-    kill -TERM "${chain_pid}" "${compiler_pid}" 2>/dev/null || true
-    wait "${chain_pid}" "${compiler_pid}" 2>/dev/null || true
+    kill -TERM "${chain_pid}" "${compiler_pid}" "${deployer_pid}" "${wallet_pid}" "${memory_pid}" 2>/dev/null || true
+    wait "${chain_pid}" "${compiler_pid}" "${deployer_pid}" "${wallet_pid}" "${memory_pid}" 2>/dev/null || true
     exit 0
 }
 trap shutdown TERM INT
 
-# If either service exits, propagate the failure to the container.
+# If any service exits, propagate the failure to the container.
 while true; do
-    if ! kill -0 "${chain_pid}" 2>/dev/null; then
-        log "mcp-chain exited unexpectedly" >&2
-        kill -TERM "${compiler_pid}" 2>/dev/null || true
-        wait "${compiler_pid}" 2>/dev/null || true
-        exit 1
-    fi
-    if ! kill -0 "${compiler_pid}" 2>/dev/null; then
-        log "mcp-compiler exited unexpectedly" >&2
-        kill -TERM "${chain_pid}" 2>/dev/null || true
-        wait "${chain_pid}" 2>/dev/null || true
-        exit 1
-    fi
+    for pair in "chain_pid:mcp-chain" "compiler_pid:mcp-compiler" "deployer_pid:mcp-deployer" "wallet_pid:mcp-wallet" "memory_pid:mcp-memory"; do
+        varname="${pair%%:*}"
+        label="${pair##*:}"
+        eval pid=\$$varname
+        if ! kill -0 "${pid}" 2>/dev/null; then
+            log "${label} exited unexpectedly" >&2
+            kill -TERM "${chain_pid}" "${compiler_pid}" "${deployer_pid}" "${wallet_pid}" "${memory_pid}" 2>/dev/null || true
+            wait "${chain_pid}" "${compiler_pid}" "${deployer_pid}" "${wallet_pid}" "${memory_pid}" 2>/dev/null || true
+            exit 1
+        fi
+    done
     sleep 2
 done

--- a/packages/backend/src/api/agent.ts
+++ b/packages/backend/src/api/agent.ts
@@ -16,6 +16,7 @@ import { WorkspaceIdSchema } from '@crucible/types';
 import { prisma } from '../lib/prisma';
 import { subscribeAgentEvents } from '../lib/agent-bus';
 import { createApiErrorBody } from '../lib/api-error';
+import { auth } from '../lib/auth';
 
 const QuerySchema = z.object({
   workspaceId: WorkspaceIdSchema,
@@ -36,9 +37,15 @@ export const agentApi = new OpenAPIHono().get('/agent/stream', async (c) => {
 
   const workspace = await prisma.workspace.findUnique({
     where: { id: workspaceId },
-    select: { id: true },
+    select: { id: true, userId: true },
   });
   if (!workspace) {
+    return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
+  }
+
+  const session = await auth.api.getSession({ headers: c.req.raw.headers });
+  const userId = session?.user.id ?? null;
+  if (workspace.userId !== null && workspace.userId !== userId) {
     return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
   }
 

--- a/packages/backend/src/api/inference.ts
+++ b/packages/backend/src/api/inference.ts
@@ -1,49 +1,140 @@
 /**
  * Inference router — `POST /api/prompt`.
  *
- * Accepts a user prompt, calls an OpenAI-compatible Chat Completions endpoint
- * (env-configured base URL + API key + model), streams the model's tokens back
- * over the workspace's agent event bus as `thinking` deltas, and emits a final
- * `message` + `inference_receipt` + `done` event.
- *
- * The HTTP response itself is small and synchronous: it returns a `streamId`
- * (the workspace id) and kicks the streaming work off in the background. The
- * frontend reads tokens from the existing `/api/agent/stream` SSE feed.
+ * Accepts a user prompt, wires up the `AgentAdapter` from local backend libs,
+ * and delegates to `runAgentTurn` from `@crucible/agent`.  The HTTP response
+ * is small and synchronous (202 + streamId); token deltas and tool events flow
+ * over the existing `/api/agent/stream` SSE feed.
  */
 
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
-import { randomUUID } from 'node:crypto';
 import {
   ApiErrorSchema,
   PromptRequestSchema,
   PromptResponseSchema,
   StreamIdSchema,
-  InferenceReceiptIdSchema,
 } from '@crucible/types';
+import { runAgentTurn, type AgentAdapter, type AgentConfig } from '@crucible/agent';
+import { exec } from 'node:child_process';
 import { prisma } from '../lib/prisma';
 import { createApiErrorBody } from '../lib/api-error';
 import { nextAgentSeq, publishAgentEvent } from '../lib/agent-bus';
+import { collectWorkspaceFiles, workspaceHostPath, writeWorkspaceFile } from '../lib/workspace-fs';
+import { executeRuntimeTool } from '../lib/tool-exec';
+import { buildOgAgentConfig } from '../lib/og-adapter';
 
-// ── OpenAI-compatible client config (env-driven) ─────────────────────────────
+// ── Config ───────────────────────────────────────────────────────────────────
 
-function readInferenceConfig():
-  | { ok: true; baseUrl: string; apiKey: string; model: string }
-  | { ok: false; reason: string } {
+/**
+ * Return the active AgentConfig.
+ * 0G Compute is tried first (requires OG_PROVIDER_ADDRESS + OG_PRIVATE_KEY).
+ * Falls back to the OpenAI-compatible endpoint env vars when 0G is absent or
+ * returns an error.
+ */
+async function resolveAgentConfig(): Promise<
+  { ok: true; config: AgentConfig } | { ok: false; reason: string }
+> {
+  try {
+    const og = await buildOgAgentConfig();
+    if (og) return { ok: true, config: og };
+  } catch (err) {
+    // 0G init failed (e.g. no balance, provider offline) — fall through.
+    console.warn(
+      '[inference] 0G Compute init failed, falling back:',
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  // OpenAI-compatible fallback.
   const baseUrl = process.env['OPENAI_BASE_URL'];
   const apiKey = process.env['OPENAI_API_KEY'];
   const model = process.env['OPENAI_MODEL'];
   if (!baseUrl) return { ok: false, reason: 'OPENAI_BASE_URL is not set' };
   if (!apiKey) return { ok: false, reason: 'OPENAI_API_KEY is not set' };
   if (!model) return { ok: false, reason: 'OPENAI_MODEL is not set' };
-  // Strip trailing slash so we can append /chat/completions.
-  return { ok: true, baseUrl: baseUrl.replace(/\/+$/u, ''), apiKey, model };
+  return {
+    ok: true,
+    config: {
+      baseUrl: baseUrl.replace(/\/+$/u, ''),
+      apiKey,
+      model,
+      provider: 'openai-compatible',
+    },
+  };
 }
 
-const SYSTEM_PROMPT =
-  'You are Crucible, an in-browser agent IDE for solidity smart contracts. ' +
-  'You help the user write, compile, and ship Solidity. Be concise. Use code ' +
-  'fences for any code. Do not invent tool calls — tool wiring is provided ' +
-  'separately by the runtime.';
+// ── AgentAdapter implementation ──────────────────────────────────────────────
+
+function buildAdapter(): AgentAdapter {
+  return {
+    getWorkspaceFiles: async (workspaceId) => collectWorkspaceFiles(workspaceHostPath(workspaceId)),
+
+    writeFile: async (workspaceId, filePath, content) =>
+      writeWorkspaceFile(workspaceId, filePath, content),
+
+    runShell: async (workspaceId, cmd) => {
+      const workspaceDir = workspaceHostPath(workspaceId);
+      return new Promise((resolve) => {
+        exec(cmd, { cwd: workspaceDir, maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
+          resolve({
+            stdout: stdout ?? '',
+            stderr: stderr ?? err?.message ?? '',
+            exitCode: err?.code ?? 0,
+          });
+        });
+      });
+    },
+
+    executeMcpTool: async (workspaceId, server, toolName, args) => {
+      const outcome = await executeRuntimeTool({
+        workspaceId,
+        server: server as
+          | 'chain'
+          | 'compiler'
+          | 'deployer'
+          | 'wallet'
+          | 'terminal'
+          | 'memory'
+          | 'mesh',
+        tool: toolName,
+        args,
+      });
+      if (!outcome.ok) throw new Error(outcome.error);
+      return outcome.result;
+    },
+
+    publishEvent: (workspaceId, event) => publishAgentEvent(workspaceId, event),
+
+    nextSeq: (workspaceId) => nextAgentSeq(workspaceId),
+  };
+}
+
+// ── Fire-and-forget orchestration ────────────────────────────────────────────
+
+async function runInference(workspaceId: string, prompt: string): Promise<void> {
+  const resolved = await resolveAgentConfig();
+  const streamId = StreamIdSchema.parse(workspaceId);
+
+  if (!resolved.ok) {
+    const seq = nextAgentSeq(workspaceId);
+    publishAgentEvent(workspaceId, {
+      streamId,
+      seq,
+      emittedAt: Date.now(),
+      type: 'error',
+      message: `Inference unavailable: ${resolved.reason}`,
+    });
+    publishAgentEvent(workspaceId, {
+      streamId,
+      seq: nextAgentSeq(workspaceId),
+      emittedAt: Date.now(),
+      type: 'done',
+    });
+    return;
+  }
+
+  await runAgentTurn(workspaceId, prompt, resolved.config, buildAdapter());
+}
 
 // ── OpenAPI route definition ─────────────────────────────────────────────────
 
@@ -75,188 +166,6 @@ const promptRoute = createRoute({
     },
   },
 });
-
-// ── Streaming helpers ────────────────────────────────────────────────────────
-
-interface OpenAIDelta {
-  choices?: Array<{ delta?: { content?: string }; finish_reason?: string | null }>;
-  usage?: { prompt_tokens?: number; completion_tokens?: number };
-}
-
-/** Parse an OpenAI-style SSE stream into delta tokens + a final usage block. */
-async function* parseOpenAIStream(
-  body: ReadableStream<Uint8Array>,
-): AsyncGenerator<
-  | { kind: 'delta'; text: string }
-  | { kind: 'usage'; promptTokens: number; completionTokens: number }
-> {
-  const reader = body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
-  let usage: { promptTokens: number; completionTokens: number } | null = null;
-
-  for (;;) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buffer += decoder.decode(value, { stream: true });
-
-    let lineEnd: number;
-    while ((lineEnd = buffer.indexOf('\n')) !== -1) {
-      const rawLine = buffer.slice(0, lineEnd).trim();
-      buffer = buffer.slice(lineEnd + 1);
-      if (!rawLine.startsWith('data:')) continue;
-      const payload = rawLine.slice(5).trim();
-      if (payload === '[DONE]') continue;
-
-      let chunk: OpenAIDelta;
-      try {
-        chunk = JSON.parse(payload) as OpenAIDelta;
-      } catch {
-        continue;
-      }
-      const delta = chunk.choices?.[0]?.delta?.content;
-      if (typeof delta === 'string' && delta.length > 0) {
-        yield { kind: 'delta', text: delta };
-      }
-      if (chunk.usage) {
-        usage = {
-          promptTokens: chunk.usage.prompt_tokens ?? 0,
-          completionTokens: chunk.usage.completion_tokens ?? 0,
-        };
-      }
-    }
-  }
-
-  if (usage) yield { kind: 'usage', ...usage };
-}
-
-/** Fire-and-forget streaming run — publishes events to the agent bus. */
-async function runInference(workspaceId: string, prompt: string): Promise<void> {
-  const cfg = readInferenceConfig();
-  const streamId = StreamIdSchema.parse(workspaceId);
-
-  // The base every emitted event needs. Sequence numbers come from the bus
-  // helper so they stay monotonic across all event sources.
-  const baseEvent = (): { streamId: typeof streamId; seq: number; emittedAt: number } => ({
-    streamId,
-    seq: nextAgentSeq(workspaceId),
-    emittedAt: Date.now(),
-  });
-
-  if (!cfg.ok) {
-    publishAgentEvent(workspaceId, {
-      ...baseEvent(),
-      type: 'error',
-      message: `Inference unavailable: ${cfg.reason}`,
-    });
-    publishAgentEvent(workspaceId, { ...baseEvent(), type: 'done' });
-    return;
-  }
-
-  // Echo the user's prompt back as a `message` so the chat rail shows it
-  // alongside the assistant's response.
-  publishAgentEvent(workspaceId, {
-    ...baseEvent(),
-    type: 'message',
-    content: `**you:** ${prompt}`,
-  });
-
-  let response: Response;
-  try {
-    response = await fetch(`${cfg.baseUrl}/chat/completions`, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        authorization: `Bearer ${cfg.apiKey}`,
-      },
-      body: JSON.stringify({
-        model: cfg.model,
-        stream: true,
-        // Many OpenAI-compatible providers honour `stream_options.include_usage`
-        // to emit a final usage block. Harmless when ignored.
-        stream_options: { include_usage: true },
-        messages: [
-          { role: 'system', content: SYSTEM_PROMPT },
-          { role: 'user', content: prompt },
-        ],
-      }),
-    });
-  } catch (err) {
-    publishAgentEvent(workspaceId, {
-      ...baseEvent(),
-      type: 'error',
-      message: `Inference request failed: ${err instanceof Error ? err.message : String(err)}`,
-    });
-    publishAgentEvent(workspaceId, { ...baseEvent(), type: 'done' });
-    return;
-  }
-
-  if (!response.ok || !response.body) {
-    const text = await response.text().catch(() => '');
-    publishAgentEvent(workspaceId, {
-      ...baseEvent(),
-      type: 'error',
-      message: `Inference HTTP ${response.status}: ${text.slice(0, 500)}`,
-    });
-    publishAgentEvent(workspaceId, { ...baseEvent(), type: 'done' });
-    return;
-  }
-
-  let full = '';
-  let promptTokens = 0;
-  let completionTokens = 0;
-
-  try {
-    for await (const chunk of parseOpenAIStream(response.body as ReadableStream<Uint8Array>)) {
-      if (chunk.kind === 'delta') {
-        full += chunk.text;
-        // Emit each delta as a `thinking` frame so the chat rail can stream
-        // tokens. The final consolidated reply is emitted as `message` below.
-        publishAgentEvent(workspaceId, {
-          ...baseEvent(),
-          type: 'thinking',
-          text: chunk.text,
-        });
-      } else {
-        promptTokens = chunk.promptTokens;
-        completionTokens = chunk.completionTokens;
-      }
-    }
-  } catch (err) {
-    publishAgentEvent(workspaceId, {
-      ...baseEvent(),
-      type: 'error',
-      message: `Inference stream broke: ${err instanceof Error ? err.message : String(err)}`,
-    });
-    publishAgentEvent(workspaceId, { ...baseEvent(), type: 'done' });
-    return;
-  }
-
-  if (full.length > 0) {
-    publishAgentEvent(workspaceId, {
-      ...baseEvent(),
-      type: 'message',
-      content: full,
-    });
-  }
-
-  publishAgentEvent(workspaceId, {
-    ...baseEvent(),
-    type: 'inference_receipt',
-    receipt: {
-      id: InferenceReceiptIdSchema.parse(randomUUID()),
-      provider: 'openai-compatible',
-      model: cfg.model,
-      attestation: null,
-      // Until 0G is wired, every fallback call is admin_override.
-      fallbackReason: 'admin_override',
-      promptTokens,
-      completionTokens,
-      createdAt: Date.now(),
-    },
-  });
-  publishAgentEvent(workspaceId, { ...baseEvent(), type: 'done' });
-}
 
 // ── Router ───────────────────────────────────────────────────────────────────
 

--- a/packages/backend/src/api/inference.ts
+++ b/packages/backend/src/api/inference.ts
@@ -13,6 +13,7 @@ import {
   PromptRequestSchema,
   PromptResponseSchema,
   StreamIdSchema,
+  type FallbackReason,
 } from '@crucible/types';
 import { runAgentTurn, type AgentAdapter, type AgentConfig } from '@crucible/agent';
 import { exec } from 'node:child_process';
@@ -22,6 +23,7 @@ import { nextAgentSeq, publishAgentEvent } from '../lib/agent-bus';
 import { collectWorkspaceFiles, workspaceHostPath, writeWorkspaceFile } from '../lib/workspace-fs';
 import { executeRuntimeTool } from '../lib/tool-exec';
 import { buildOgAgentConfig } from '../lib/og-adapter';
+import { auth } from '../lib/auth';
 
 // ── Config ───────────────────────────────────────────────────────────────────
 
@@ -34,15 +36,18 @@ import { buildOgAgentConfig } from '../lib/og-adapter';
 async function resolveAgentConfig(): Promise<
   { ok: true; config: AgentConfig } | { ok: false; reason: string }
 > {
+  let fallbackReason: FallbackReason;
+
   try {
     const og = await buildOgAgentConfig();
     if (og) return { ok: true, config: og };
+    // buildOgAgentConfig returned null — 0G env vars not configured.
+    fallbackReason = 'admin_override';
   } catch (err) {
     // 0G init failed (e.g. no balance, provider offline) — fall through.
-    console.warn(
-      '[inference] 0G Compute init failed, falling back:',
-      err instanceof Error ? err.message : String(err),
-    );
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn('[inference] 0G Compute init failed, falling back:', msg);
+    fallbackReason = 'provider_unavailable';
   }
 
   // OpenAI-compatible fallback.
@@ -59,6 +64,7 @@ async function resolveAgentConfig(): Promise<
       apiKey,
       model,
       provider: 'openai-compatible',
+      fallbackReason,
     },
   };
 }
@@ -67,7 +73,17 @@ async function resolveAgentConfig(): Promise<
 
 function buildAdapter(): AgentAdapter {
   return {
-    getWorkspaceFiles: async (workspaceId) => collectWorkspaceFiles(workspaceHostPath(workspaceId)),
+    getWorkspaceFiles: async (workspaceId) => {
+      const ws = await prisma.workspace.findUnique({
+        where: { id: workspaceId },
+        select: { directoryPath: true },
+      });
+      const dir =
+        ws?.directoryPath && !ws.directoryPath.startsWith('pending://')
+          ? ws.directoryPath
+          : workspaceHostPath(workspaceId);
+      return collectWorkspaceFiles(dir);
+    },
 
     writeFile: async (workspaceId, filePath, content) =>
       writeWorkspaceFile(workspaceId, filePath, content),
@@ -156,6 +172,10 @@ const promptRoute = createRoute({
       content: { 'application/json': { schema: ApiErrorSchema } },
       description: 'Bad request',
     },
+    401: {
+      content: { 'application/json': { schema: ApiErrorSchema } },
+      description: 'Unauthorized',
+    },
     404: {
       content: { 'application/json': { schema: ApiErrorSchema } },
       description: 'Workspace not found',
@@ -182,11 +202,21 @@ export const inferenceApi = new OpenAPIHono({
 }).openapi(promptRoute, async (c) => {
   const { workspaceId, prompt } = c.req.valid('json');
 
+  const session = await auth.api.getSession({ headers: c.req.raw.headers });
+  const userId = session?.user.id ?? null;
+
+  if (!userId) {
+    return c.json(createApiErrorBody('unauthorized', 'Authentication required'), 401);
+  }
+
   const workspace = await prisma.workspace.findUnique({
     where: { id: workspaceId },
-    select: { id: true },
+    select: { id: true, userId: true },
   });
   if (!workspace) {
+    return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
+  }
+  if (workspace.userId !== userId) {
     return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
   }
 

--- a/packages/backend/src/api/inference.ts
+++ b/packages/backend/src/api/inference.ts
@@ -21,7 +21,7 @@ import { prisma } from '../lib/prisma';
 import { createApiErrorBody } from '../lib/api-error';
 import { nextAgentSeq, publishAgentEvent } from '../lib/agent-bus';
 import { collectWorkspaceFiles, workspaceHostPath, writeWorkspaceFile } from '../lib/workspace-fs';
-import { executeRuntimeTool } from '../lib/tool-exec';
+import { getWorkspaceContainerPorts, runtimeServiceBaseUrl } from '../lib/runtime-docker';
 import { buildOgAgentConfig } from '../lib/og-adapter';
 import { auth } from '../lib/auth';
 
@@ -101,24 +101,6 @@ function buildAdapter(): AgentAdapter {
       });
     },
 
-    executeMcpTool: async (workspaceId, server, toolName, args) => {
-      const outcome = await executeRuntimeTool({
-        workspaceId,
-        server: server as
-          | 'chain'
-          | 'compiler'
-          | 'deployer'
-          | 'wallet'
-          | 'terminal'
-          | 'memory'
-          | 'mesh',
-        tool: toolName,
-        args,
-      });
-      if (!outcome.ok) throw new Error(outcome.error);
-      return outcome.result;
-    },
-
     publishEvent: (workspaceId, event) => publishAgentEvent(workspaceId, event),
 
     nextSeq: (workspaceId) => nextAgentSeq(workspaceId),
@@ -149,7 +131,23 @@ async function runInference(workspaceId: string, prompt: string): Promise<void> 
     return;
   }
 
-  await runAgentTurn(workspaceId, prompt, resolved.config, buildAdapter());
+  // Build MCP server URLs from the live container port map.
+  const mcpServerUrls: Partial<
+    Record<'chain' | 'compiler' | 'deployer' | 'wallet' | 'memory', string>
+  > = {};
+  try {
+    const ports = await getWorkspaceContainerPorts(workspaceId);
+    if (ports) {
+      for (const key of ['chain', 'compiler', 'deployer', 'wallet', 'memory'] as const) {
+        const port = ports[key];
+        if (port !== null) mcpServerUrls[key] = `${runtimeServiceBaseUrl(port)}/mcp`;
+      }
+    }
+  } catch {
+    // Container not running yet — agent will degrade without MCP tools.
+  }
+
+  await runAgentTurn(workspaceId, prompt, { ...resolved.config, mcpServerUrls }, buildAdapter());
 }
 
 // ── OpenAPI route definition ─────────────────────────────────────────────────

--- a/packages/backend/src/api/runtime.ts
+++ b/packages/backend/src/api/runtime.ts
@@ -22,7 +22,9 @@ import { randomUUID } from 'node:crypto';
 import { executeRuntimeTool } from '../lib/tool-exec';
 import { createApiErrorBody } from '../lib/api-error';
 import { provisionWorkspaceDirectory, workspaceHostPath } from '../lib/workspace-fs';
-import { nextAgentSeq, publishAgentEvent } from '../lib/agent-bus';
+import { nextAgentSeq, publishAgentEvent, cleanupAgentBus } from '../lib/agent-bus';
+import { auth } from '../lib/auth';
+import { cleanupWorkspacePty } from '../lib/pty-manager';
 
 // ── OpenAPI route definition ─────────────────────────────────────────────────
 
@@ -112,6 +114,8 @@ function toDescriptor(runtime: {
 
 export const runtimeApi = baseRuntimeApi.openapi(runtimeRoute, async (c) => {
   const parsed = { success: true as const, data: c.req.valid('json') };
+  const session = await auth.api.getSession({ headers: c.req.raw.headers });
+  const userId = session?.user.id ?? null;
 
   if (parsed.data.type === 'open_workspace') {
     const workspace = await prisma.workspace.findUnique({
@@ -120,6 +124,10 @@ export const runtimeApi = baseRuntimeApi.openapi(runtimeRoute, async (c) => {
     });
 
     if (!workspace) {
+      return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
+    }
+
+    if (workspace.userId !== null && workspace.userId !== userId) {
       return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
     }
 
@@ -169,9 +177,11 @@ export const runtimeApi = baseRuntimeApi.openapi(runtimeRoute, async (c) => {
         data: {
           status: container.ready ? 'ready' : 'degraded',
           startedAt: new Date(container.startedAtMs),
-          terminalSessionId: `${workspace.id}-terminal`,
           chainPort: container.ports.chain,
           compilerPort: container.ports.compiler,
+          deployerPort: container.ports.deployer,
+          walletPort: container.ports.wallet,
+          terminalPort: container.ports.terminal,
         },
       });
 
@@ -203,7 +213,13 @@ export const runtimeApi = baseRuntimeApi.openapi(runtimeRoute, async (c) => {
   }
 
   if (parsed.data.type === 'runtime_status') {
-    const runtimes = await prisma.workspaceRuntime.findMany();
+    const runtimes = await prisma.workspaceRuntime.findMany({
+      where: {
+        workspace: {
+          OR: [{ userId }, { userId: null }],
+        },
+      },
+    });
     const reconciled = await Promise.all(
       runtimes.map(async (runtime) => {
         const state = await getWorkspaceContainerState(runtime.workspaceId).catch(() => 'missing');
@@ -237,9 +253,11 @@ export const runtimeApi = baseRuntimeApi.openapi(runtimeRoute, async (c) => {
             data: {
               status: 'ready',
               startedAt: new Date(),
-              terminalSessionId: `${runtime.workspaceId}-terminal`,
               chainPort: ports?.chain ?? null,
               compilerPort: ports?.compiler ?? null,
+              deployerPort: ports?.deployer ?? null,
+              walletPort: ports?.wallet ?? null,
+              terminalPort: ports?.terminal ?? null,
             },
           });
         }
@@ -267,8 +285,14 @@ export const runtimeApi = baseRuntimeApi.openapi(runtimeRoute, async (c) => {
       return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
     }
 
+    if (workspace.userId !== null && workspace.userId !== userId) {
+      return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
+    }
+
     try {
       await stopWorkspaceContainer(workspace.id);
+      cleanupAgentBus(workspace.id);
+      cleanupWorkspacePty(workspace.id);
 
       if (workspace.runtime) {
         await prisma.workspaceRuntime.update({
@@ -308,10 +332,14 @@ export const runtimeApi = baseRuntimeApi.openapi(runtimeRoute, async (c) => {
   if (parsed.data.type === 'tool_exec') {
     const workspace = await prisma.workspace.findUnique({
       where: { id: parsed.data.workspaceId },
-      select: { id: true },
+      select: { id: true, userId: true },
     });
 
     if (!workspace) {
+      return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
+    }
+
+    if (workspace.userId !== null && workspace.userId !== userId) {
       return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
     }
 

--- a/packages/backend/src/api/runtime.ts
+++ b/packages/backend/src/api/runtime.ts
@@ -25,6 +25,7 @@ import { provisionWorkspaceDirectory, workspaceHostPath } from '../lib/workspace
 import { nextAgentSeq, publishAgentEvent, cleanupAgentBus } from '../lib/agent-bus';
 import { auth } from '../lib/auth';
 import { cleanupWorkspacePty } from '../lib/pty-manager';
+import { startPreview, stopPreview } from '../lib/preview-manager';
 
 // ── OpenAPI route definition ─────────────────────────────────────────────────
 
@@ -193,6 +194,11 @@ export const runtimeApi = baseRuntimeApi.openapi(runtimeRoute, async (c) => {
         },
       });
 
+      // Start the per-workspace Vite preview server in the background.
+      void startPreview(workspace.id, workspaceHostPath(workspace.id)).catch((err) => {
+        console.warn(`[runtime ${workspace.id}] preview start failed:`, err);
+      });
+
       const response = RuntimeResponseSchema.parse({
         correlationId: parsed.data.correlationId,
         type: 'open_workspace',
@@ -297,6 +303,7 @@ export const runtimeApi = baseRuntimeApi.openapi(runtimeRoute, async (c) => {
 
     try {
       await stopWorkspaceContainer(workspace.id);
+      stopPreview(workspace.id);
       cleanupAgentBus(workspace.id);
       cleanupWorkspacePty(workspace.id);
 

--- a/packages/backend/src/api/runtime.ts
+++ b/packages/backend/src/api/runtime.ts
@@ -46,6 +46,10 @@ const runtimeRoute = createRoute({
       content: { 'application/json': { schema: ApiErrorSchema } },
       description: 'Bad request',
     },
+    401: {
+      content: { 'application/json': { schema: ApiErrorSchema } },
+      description: 'Unauthorized',
+    },
     404: {
       content: { 'application/json': { schema: ApiErrorSchema } },
       description: 'Not found',
@@ -117,6 +121,10 @@ export const runtimeApi = baseRuntimeApi.openapi(runtimeRoute, async (c) => {
   const session = await auth.api.getSession({ headers: c.req.raw.headers });
   const userId = session?.user.id ?? null;
 
+  if (!userId) {
+    return c.json(createApiErrorBody('unauthorized', 'Authentication required'), 401);
+  }
+
   if (parsed.data.type === 'open_workspace') {
     const workspace = await prisma.workspace.findUnique({
       where: { id: parsed.data.workspaceId },
@@ -127,7 +135,7 @@ export const runtimeApi = baseRuntimeApi.openapi(runtimeRoute, async (c) => {
       return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
     }
 
-    if (workspace.userId !== null && workspace.userId !== userId) {
+    if (workspace.userId !== userId) {
       return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
     }
 
@@ -215,9 +223,7 @@ export const runtimeApi = baseRuntimeApi.openapi(runtimeRoute, async (c) => {
   if (parsed.data.type === 'runtime_status') {
     const runtimes = await prisma.workspaceRuntime.findMany({
       where: {
-        workspace: {
-          OR: [{ userId }, { userId: null }],
-        },
+        workspace: { userId },
       },
     });
     const reconciled = await Promise.all(
@@ -285,7 +291,7 @@ export const runtimeApi = baseRuntimeApi.openapi(runtimeRoute, async (c) => {
       return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
     }
 
-    if (workspace.userId !== null && workspace.userId !== userId) {
+    if (workspace.userId !== userId) {
       return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
     }
 
@@ -339,7 +345,7 @@ export const runtimeApi = baseRuntimeApi.openapi(runtimeRoute, async (c) => {
       return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
     }
 
-    if (workspace.userId !== null && workspace.userId !== userId) {
+    if (workspace.userId !== userId) {
       return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
     }
 

--- a/packages/backend/src/api/terminal.ts
+++ b/packages/backend/src/api/terminal.ts
@@ -1,0 +1,105 @@
+/**
+ * WebSocket PTY terminal endpoint.
+ *
+ * `GET /ws/terminal?sessionId=<id>` — attach to an existing PTY session.
+ * `GET /ws/terminal?workspaceId=<id>` — get-or-create the workspace's PTY
+ *   session, then attach to it.
+ *
+ * Frame format (JSON):
+ *   Server → client:  `{ kind: 'data', data: string }` | `{ kind: 'exit', exitCode: number }`
+ *   Client → server:  `{ kind: 'data', data: string }` | `{ kind: 'resize', cols: number, rows: number }`
+ */
+
+import { Hono } from 'hono';
+import { upgradeWebSocket } from '../index';
+import { getPtySession, getPtySessionByWorkspace, getOrCreatePtySession } from '../lib/pty-manager';
+import { TerminalFrameSchema } from '@crucible/types';
+import { prisma } from '../lib/prisma';
+import { auth } from '../lib/auth';
+
+export const terminalApi = new Hono().get(
+  '/ws/terminal',
+  upgradeWebSocket(async (c) => {
+    const sessionId = c.req.query('sessionId');
+    const workspaceId = c.req.query('workspaceId');
+
+    // Resolve session — prefer sessionId, fall back to workspaceId.
+    let session = sessionId
+      ? getPtySession(sessionId)
+      : workspaceId
+        ? getPtySessionByWorkspace(workspaceId)
+        : undefined;
+
+    // If no session exists yet and we have a workspaceId, create one.
+    if (!session && workspaceId) {
+      // Ownership check before spawning.
+      const authSession = await auth.api.getSession({ headers: c.req.raw.headers });
+      const userId = authSession?.user.id ?? null;
+      const workspace = await prisma.workspace.findUnique({
+        where: { id: workspaceId },
+        select: { id: true, userId: true },
+      });
+      if (!workspace || (workspace.userId !== null && workspace.userId !== userId)) {
+        // Can't send a 404 over the WebSocket upgrade path cleanly — just
+        // close immediately after the handshake.
+        return {
+          onOpen(_event, ws) {
+            ws.close(4004, 'Workspace not found');
+          },
+        };
+      }
+      session = await getOrCreatePtySession(workspaceId).catch(() => undefined);
+    }
+
+    if (!session) {
+      return {
+        onOpen(_event, ws) {
+          ws.close(4004, 'Session not found');
+        },
+      };
+    }
+
+    const resolvedSession = session;
+
+    return {
+      onOpen(_event, ws) {
+        // Forward PTY output to the client.
+        const removeData = resolvedSession.onData((data) => {
+          ws.send(JSON.stringify({ kind: 'data', data }));
+        });
+
+        const removeExit = resolvedSession.onExit((exitCode) => {
+          ws.send(JSON.stringify({ kind: 'exit', exitCode }));
+          removeData();
+          removeExit();
+          ws.close(1000, 'PTY exited');
+        });
+
+        // Store cleanup refs on the ws context object (Bun allows attaching props).
+        (ws as unknown as Record<string, unknown>)['_removeData'] = removeData;
+        (ws as unknown as Record<string, unknown>)['_removeExit'] = removeExit;
+      },
+
+      onMessage(event) {
+        const raw = typeof event.data === 'string' ? event.data : null;
+        if (!raw) return;
+
+        const parsed = TerminalFrameSchema.safeParse(JSON.parse(raw));
+        if (!parsed.success) return;
+
+        const frame = parsed.data;
+        if (frame.kind === 'data') {
+          resolvedSession.write(frame.data);
+        } else if (frame.kind === 'resize') {
+          resolvedSession.resize(frame.cols, frame.rows);
+        }
+      },
+
+      onClose(_event, ws) {
+        const ctx = ws as unknown as Record<string, unknown>;
+        (ctx['_removeData'] as (() => void) | undefined)?.();
+        (ctx['_removeExit'] as (() => void) | undefined)?.();
+      },
+    };
+  }),
+);

--- a/packages/backend/src/api/workspace.ts
+++ b/packages/backend/src/api/workspace.ts
@@ -2,6 +2,7 @@ import {
   workspaceHostPath,
   collectWorkspaceFiles,
   provisionWorkspaceDirectory,
+  writeWorkspaceFile,
 } from '../lib/workspace-fs';
 import {
   ChainStateSchema,
@@ -13,18 +14,18 @@ import {
   FileWriteRequestSchema,
   FileWriteResponseSchema,
   ApiErrorSchema,
+  StreamIdSchema,
 } from '@crucible/types';
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
 import { z } from 'zod';
 import { prisma } from '../lib/prisma';
 import { randomUUID } from 'node:crypto';
-import { createHash } from 'node:crypto';
 import { Prisma } from '../generated/prisma/client';
 import { createApiErrorBody } from '../lib/api-error';
 import { ensureWorkspaceContainer } from '../lib/runtime-docker';
+import { startPreview } from '../lib/preview-manager';
+import { publishAgentEvent, nextAgentSeq } from '../lib/agent-bus';
 import { auth } from '../lib/auth';
-import path from 'node:path';
-import { mkdir, writeFile, stat } from 'node:fs/promises';
 
 // ── OpenAPI route definitions ────────────────────────────────────────────────
 
@@ -50,6 +51,10 @@ const createWorkspaceRoute = createRoute({
       content: { 'application/json': { schema: ApiErrorSchema } },
       description: 'Conflict',
     },
+    401: {
+      content: { 'application/json': { schema: ApiErrorSchema } },
+      description: 'Unauthorized',
+    },
     500: {
       content: { 'application/json': { schema: ApiErrorSchema } },
       description: 'Internal error',
@@ -71,6 +76,10 @@ const getWorkspaceRoute = createRoute({
     400: {
       content: { 'application/json': { schema: ApiErrorSchema } },
       description: 'Bad request',
+    },
+    401: {
+      content: { 'application/json': { schema: ApiErrorSchema } },
+      description: 'Unauthorized',
     },
     404: {
       content: { 'application/json': { schema: ApiErrorSchema } },
@@ -97,6 +106,10 @@ const fileWriteRoute = createRoute({
     400: {
       content: { 'application/json': { schema: ApiErrorSchema } },
       description: 'Bad request',
+    },
+    401: {
+      content: { 'application/json': { schema: ApiErrorSchema } },
+      description: 'Unauthorized',
     },
     404: {
       content: { 'application/json': { schema: ApiErrorSchema } },
@@ -147,6 +160,12 @@ async function spawnRuntimeForWorkspace(workspaceId: string, directoryPath: stri
         terminalPort: container.ports.terminal,
       },
     });
+
+    // Start the per-workspace preview server in the background so
+    // GET /api/workspace/:id eventually returns a non-null previewUrl.
+    void startPreview(workspaceId, directoryPath).catch((err) => {
+      console.warn(`[workspace ${workspaceId}] preview start failed:`, err);
+    });
   } catch (err) {
     // Mark the runtime crashed so the UI can show a degraded state instead
     // of looking idle forever. The error itself is intentionally swallowed:
@@ -178,6 +197,11 @@ export const workspaceApi = new OpenAPIHono({
     const { name } = c.req.valid('json');
     const session = await auth.api.getSession({ headers: c.req.raw.headers });
     const userId = session?.user.id ?? null;
+
+    if (!userId) {
+      return c.json(createApiErrorBody('unauthorized', 'Authentication required'), 401);
+    }
+
     let createdId: string | null = null;
 
     try {
@@ -224,6 +248,10 @@ export const workspaceApi = new OpenAPIHono({
     const session = await auth.api.getSession({ headers: c.req.raw.headers });
     const userId = session?.user.id ?? null;
 
+    if (!userId) {
+      return c.json(createApiErrorBody('unauthorized', 'Authentication required'), 401);
+    }
+
     const row = await prisma.workspace.findUnique({
       where: { id },
       include: { runtime: true },
@@ -233,7 +261,7 @@ export const workspaceApi = new OpenAPIHono({
       return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
     }
 
-    if (row.userId !== null && row.userId !== userId) {
+    if (row.userId !== userId) {
       return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
     }
 
@@ -260,6 +288,10 @@ export const workspaceApi = new OpenAPIHono({
     const session = await auth.api.getSession({ headers: c.req.raw.headers });
     const userId = session?.user.id ?? null;
 
+    if (!userId) {
+      return c.json(createApiErrorBody('unauthorized', 'Authentication required'), 401);
+    }
+
     const row = await prisma.workspace.findUnique({
       where: { id },
       select: { id: true, userId: true, directoryPath: true },
@@ -269,7 +301,7 @@ export const workspaceApi = new OpenAPIHono({
       return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
     }
 
-    if (row.userId !== null && row.userId !== userId) {
+    if (row.userId !== userId) {
       return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
     }
 
@@ -277,43 +309,24 @@ export const workspaceApi = new OpenAPIHono({
       ? workspaceHostPath(row.id)
       : (row.directoryPath ?? workspaceHostPath(row.id));
 
-    // Resolve the full path and verify it stays within the workspace directory
-    // (defense-in-depth against path traversal even though the schema blocks `..`).
-    const resolved = path.resolve(workspaceDir, filePath);
-    if (!resolved.startsWith(workspaceDir + path.sep) && resolved !== workspaceDir) {
-      return c.json(createApiErrorBody('bad_request', 'Path escapes the workspace directory'), 400);
-    }
-
     try {
-      await mkdir(path.dirname(resolved), { recursive: true });
-      const encoded = Buffer.from(content, 'utf8');
-      await writeFile(resolved, encoded);
-      const fileStats = await stat(resolved);
+      const wf = await writeWorkspaceFile(row.id, filePath, content, workspaceDir);
 
-      const ext = path.extname(filePath).toLowerCase();
-      const langMap: Record<string, string> = {
-        '.sol': 'solidity',
-        '.ts': 'typescript',
-        '.tsx': 'typescript',
-        '.js': 'javascript',
-        '.jsx': 'javascript',
-        '.svelte': 'svelte',
-        '.json': 'json',
-        '.css': 'css',
-        '.html': 'html',
-        '.md': 'markdown',
-        '.txt': 'plaintext',
-      };
-
-      const response = FileWriteResponseSchema.parse({
-        path: filePath,
-        content,
-        lang: langMap[ext] ?? 'plaintext',
-        hash: createHash('sha256').update(encoded).digest('hex'),
-        modifiedAt: Math.trunc(fileStats.mtimeMs),
+      // Publish a file_write event so SSE subscribers (e.g. the editor)
+      // see the change without polling.
+      const streamId = StreamIdSchema.parse(row.id);
+      publishAgentEvent(row.id, {
+        streamId,
+        seq: nextAgentSeq(row.id),
+        emittedAt: Date.now(),
+        type: 'file_write',
+        path: wf.path,
+        lang: wf.lang,
+        hash: wf.hash,
+        content: wf.content,
       });
 
-      return c.json(response, 200);
+      return c.json(FileWriteResponseSchema.parse(wf), 200);
     } catch (error) {
       return c.json(
         createApiErrorBody('internal', error instanceof Error ? error.message : 'Write failed'),

--- a/packages/backend/src/api/workspace.ts
+++ b/packages/backend/src/api/workspace.ts
@@ -10,15 +10,21 @@ import {
   WorkspaceGetResponseSchema,
   WorkspaceCreateRequestSchema,
   WorkspaceCreateResponseSchema,
+  FileWriteRequestSchema,
+  FileWriteResponseSchema,
   ApiErrorSchema,
 } from '@crucible/types';
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
 import { z } from 'zod';
 import { prisma } from '../lib/prisma';
 import { randomUUID } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import { Prisma } from '../generated/prisma/client';
 import { createApiErrorBody } from '../lib/api-error';
 import { ensureWorkspaceContainer } from '../lib/runtime-docker';
+import { auth } from '../lib/auth';
+import path from 'node:path';
+import { mkdir, writeFile, stat } from 'node:fs/promises';
 
 // ── OpenAPI route definitions ────────────────────────────────────────────────
 
@@ -73,6 +79,36 @@ const getWorkspaceRoute = createRoute({
   },
 });
 
+const fileWriteRoute = createRoute({
+  method: 'put',
+  path: '/workspace/{id}/file',
+  request: {
+    params: z.object({ id: WorkspaceIdSchema }),
+    body: {
+      content: { 'application/json': { schema: FileWriteRequestSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: FileWriteResponseSchema } },
+      description: 'File written successfully',
+    },
+    400: {
+      content: { 'application/json': { schema: ApiErrorSchema } },
+      description: 'Bad request',
+    },
+    404: {
+      content: { 'application/json': { schema: ApiErrorSchema } },
+      description: 'Workspace not found',
+    },
+    500: {
+      content: { 'application/json': { schema: ApiErrorSchema } },
+      description: 'Internal error',
+    },
+  },
+});
+
 // ── Background runtime bootstrap ─────────────────────────────────────────────
 
 /**
@@ -104,9 +140,11 @@ async function spawnRuntimeForWorkspace(workspaceId: string, directoryPath: stri
       data: {
         status: container.ready ? 'ready' : 'degraded',
         startedAt: new Date(container.startedAtMs),
-        terminalSessionId: `${workspaceId}-terminal`,
         chainPort: container.ports.chain,
         compilerPort: container.ports.compiler,
+        deployerPort: container.ports.deployer,
+        walletPort: container.ports.wallet,
+        terminalPort: container.ports.terminal,
       },
     });
   } catch (err) {
@@ -138,6 +176,8 @@ export const workspaceApi = new OpenAPIHono({
 })
   .openapi(createWorkspaceRoute, async (c) => {
     const { name } = c.req.valid('json');
+    const session = await auth.api.getSession({ headers: c.req.raw.headers });
+    const userId = session?.user.id ?? null;
     let createdId: string | null = null;
 
     try {
@@ -146,6 +186,7 @@ export const workspaceApi = new OpenAPIHono({
           deployments: [],
           name,
           directoryPath: `pending://${randomUUID()}`,
+          userId,
         },
         select: { id: true },
       });
@@ -180,6 +221,8 @@ export const workspaceApi = new OpenAPIHono({
   })
   .openapi(getWorkspaceRoute, async (c) => {
     const { id } = c.req.valid('param');
+    const session = await auth.api.getSession({ headers: c.req.raw.headers });
+    const userId = session?.user.id ?? null;
 
     const row = await prisma.workspace.findUnique({
       where: { id },
@@ -187,6 +230,10 @@ export const workspaceApi = new OpenAPIHono({
     });
 
     if (!row) {
+      return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
+    }
+
+    if (row.userId !== null && row.userId !== userId) {
       return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
     }
 
@@ -206,4 +253,71 @@ export const workspaceApi = new OpenAPIHono({
     });
 
     return c.json(response, 200);
+  })
+  .openapi(fileWriteRoute, async (c) => {
+    const { id } = c.req.valid('param');
+    const { path: filePath, content } = c.req.valid('json');
+    const session = await auth.api.getSession({ headers: c.req.raw.headers });
+    const userId = session?.user.id ?? null;
+
+    const row = await prisma.workspace.findUnique({
+      where: { id },
+      select: { id: true, userId: true, directoryPath: true },
+    });
+
+    if (!row) {
+      return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
+    }
+
+    if (row.userId !== null && row.userId !== userId) {
+      return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
+    }
+
+    const workspaceDir = row.directoryPath?.startsWith('pending://')
+      ? workspaceHostPath(row.id)
+      : (row.directoryPath ?? workspaceHostPath(row.id));
+
+    // Resolve the full path and verify it stays within the workspace directory
+    // (defense-in-depth against path traversal even though the schema blocks `..`).
+    const resolved = path.resolve(workspaceDir, filePath);
+    if (!resolved.startsWith(workspaceDir + path.sep) && resolved !== workspaceDir) {
+      return c.json(createApiErrorBody('bad_request', 'Path escapes the workspace directory'), 400);
+    }
+
+    try {
+      await mkdir(path.dirname(resolved), { recursive: true });
+      const encoded = Buffer.from(content, 'utf8');
+      await writeFile(resolved, encoded);
+      const fileStats = await stat(resolved);
+
+      const ext = path.extname(filePath).toLowerCase();
+      const langMap: Record<string, string> = {
+        '.sol': 'solidity',
+        '.ts': 'typescript',
+        '.tsx': 'typescript',
+        '.js': 'javascript',
+        '.jsx': 'javascript',
+        '.svelte': 'svelte',
+        '.json': 'json',
+        '.css': 'css',
+        '.html': 'html',
+        '.md': 'markdown',
+        '.txt': 'plaintext',
+      };
+
+      const response = FileWriteResponseSchema.parse({
+        path: filePath,
+        content,
+        lang: langMap[ext] ?? 'plaintext',
+        hash: createHash('sha256').update(encoded).digest('hex'),
+        modifiedAt: Math.trunc(fileStats.mtimeMs),
+      });
+
+      return c.json(response, 200);
+    } catch (error) {
+      return c.json(
+        createApiErrorBody('internal', error instanceof Error ? error.message : 'Write failed'),
+        500,
+      );
+    }
   });

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,11 +1,15 @@
 import { OpenAPIHono } from '@hono/zod-openapi';
 import { cors } from 'hono/cors';
 import { createMiddleware } from 'hono/factory';
+import { upgradeWebSocket, websocket } from 'hono/bun';
 import { auth } from './lib/auth';
 import { agentApi } from './api/agent';
 import { runtimeApi } from './api/runtime';
 import { workspaceApi } from './api/workspace';
 import { inferenceApi } from './api/inference';
+import { terminalApi } from './api/terminal';
+
+export { upgradeWebSocket };
 
 const app = new OpenAPIHono();
 
@@ -31,7 +35,7 @@ app.use(
       return null;
     },
     exposeHeaders: ['Content-Length'],
-    allowMethods: ['POST', 'GET', 'OPTIONS'],
+    allowMethods: ['POST', 'GET', 'PUT', 'DELETE', 'OPTIONS'],
     allowHeaders: ['Content-Type', 'Authorization'],
   }),
 );
@@ -58,7 +62,8 @@ const apiRoutes = app
   .route('/api', workspaceApi)
   .route('/api', runtimeApi)
   .route('/api', agentApi)
-  .route('/api', inferenceApi);
+  .route('/api', inferenceApi)
+  .route('/', terminalApi);
 
 apiRoutes.doc('/doc', { openapi: '3.0.0', info: { version: '0.0.0', title: 'crucible-backend' } });
 
@@ -75,4 +80,5 @@ export default {
   port,
   idleTimeout: 0,
   fetch: apiRoutes.fetch,
+  websocket,
 };

--- a/packages/backend/src/lib/agent-bus.ts
+++ b/packages/backend/src/lib/agent-bus.ts
@@ -120,3 +120,13 @@ export function subscribeAgentEvents(workspaceId: string): {
 
   return { events, unsubscribe };
 }
+
+/**
+ * Remove all in-memory bus state for the given workspace. Call this when a
+ * workspace is closed or deleted so subscribers and sequence counters do not
+ * accumulate indefinitely.
+ */
+export function cleanupAgentBus(workspaceId: string): void {
+  subscribers.delete(workspaceId);
+  sequence.delete(workspaceId);
+}

--- a/packages/backend/src/lib/og-adapter.ts
+++ b/packages/backend/src/lib/og-adapter.ts
@@ -1,0 +1,71 @@
+/**
+ * 0G Compute inference adapter.
+ *
+ * Builds an `AgentConfig` that routes inference through a 0G Compute provider.
+ * Returns `null` when the required environment variables are absent so callers
+ * can fall back to the OpenAI-compatible path transparently.
+ *
+ * Required environment variables:
+ *   OG_PROVIDER_ADDRESS  – Ethereum address of the 0G Compute provider
+ *   OG_PRIVATE_KEY       – Hex private key of the wallet funding the account
+ *
+ * Optional:
+ *   OG_RPC_URL           – EVM RPC URL (defaults to 0G testnet)
+ */
+
+import { ethers } from 'ethers';
+import { createZGComputeNetworkBroker } from '@0glabs/0g-serving-broker';
+import type { AgentConfig } from '@crucible/agent';
+
+const OG_RPC_DEFAULT = 'https://evmrpc-testnet.0g.ai';
+
+/**
+ * Build an `AgentConfig` that routes inference through 0G Compute.
+ *
+ * Calls `getServiceMetadata` to discover the provider's endpoint and model,
+ * then `getRequestHeaders` to generate per-request signed auth headers.
+ * The Authorization Bearer token is extracted into `apiKey` so the AI SDK
+ * sets it normally; remaining signed headers are passed via `config.headers`.
+ *
+ * Returns `null` when `OG_PROVIDER_ADDRESS` or `OG_PRIVATE_KEY` are not set.
+ */
+export async function buildOgAgentConfig(): Promise<AgentConfig | null> {
+  const providerAddress = process.env['OG_PROVIDER_ADDRESS'];
+  const privateKey = process.env['OG_PRIVATE_KEY'];
+  if (!providerAddress || !privateKey) return null;
+
+  const rpcUrl = process.env['OG_RPC_URL'] ?? OG_RPC_DEFAULT;
+
+  const rpcProvider = new ethers.JsonRpcProvider(rpcUrl);
+  const wallet = new ethers.Wallet(privateKey, rpcProvider);
+  const broker = await createZGComputeNetworkBroker(wallet);
+
+  const { endpoint, model } = await broker.inference.getServiceMetadata(providerAddress);
+
+  // Per-request signed headers include Authorization and 0G-specific fields.
+  // ServingRequestHeaders has no index signature, so we cast through unknown.
+  const rawHeaders = (await broker.inference.getRequestHeaders(
+    providerAddress,
+  )) as unknown as Record<string, string>;
+
+  // Split Authorization from the rest so the AI SDK handles Bearer correctly.
+  const authHeader = rawHeaders['Authorization'] ?? rawHeaders['authorization'] ?? '';
+  const apiKey = authHeader.replace(/^Bearer\s+/iu, '');
+
+  const extraHeaders: Record<string, string> = {};
+  for (const [k, v] of Object.entries(rawHeaders)) {
+    if (k.toLowerCase() !== 'authorization') {
+      extraHeaders[k] = v;
+    }
+  }
+
+  // With exactOptionalPropertyTypes we must omit the key entirely rather than
+  // assign undefined to it.
+  return {
+    baseUrl: endpoint,
+    apiKey,
+    model,
+    ...(Object.keys(extraHeaders).length > 0 ? { headers: extraHeaders } : {}),
+    provider: '0g-compute' as const,
+  };
+}

--- a/packages/backend/src/lib/preview-manager.ts
+++ b/packages/backend/src/lib/preview-manager.ts
@@ -1,0 +1,106 @@
+/**
+ * Per-workspace Vite preview supervisor.
+ *
+ * Starts a `vite dev` process for the workspace's `frontend/` directory,
+ * assigns a host port, and persists `previewUrl` to the DB so the frontend
+ * shell can iframe it.
+ *
+ * One Vite process per workspace. Subsequent calls to `startPreview` while
+ * a process is already running return the existing URL.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createServer } from 'node:net';
+import type { EventEmitter } from 'node:events';
+import path from 'node:path';
+import { prisma } from './prisma';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type PreviewEntry = {
+  process: ChildProcess;
+  port: number;
+  previewUrl: string;
+};
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+const previews = new Map<string, PreviewEntry>();
+
+// ---------------------------------------------------------------------------
+// Port helpers
+// ---------------------------------------------------------------------------
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    (server as unknown as EventEmitter).on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      server.close(() => resolve((addr as { port: number }).port));
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Start the Vite dev server for the workspace's `frontend/` directory.
+ * Returns the preview URL. No-ops if already running.
+ */
+export async function startPreview(workspaceId: string, workspaceDir: string): Promise<string> {
+  const existing = previews.get(workspaceId);
+  if (existing) return existing.previewUrl;
+
+  const port = await getFreePort();
+  const frontendDir = path.join(workspaceDir, 'frontend');
+  const previewUrl = `http://localhost:${port}`;
+
+  const vite = spawn(
+    'bun',
+    ['run', '--cwd', frontendDir, 'vite', '--port', String(port), '--host', '127.0.0.1'],
+    {
+      cwd: frontendDir,
+      env: { ...process.env, FORCE_COLOR: '0' },
+      stdio: 'pipe',
+    },
+  );
+
+  (vite as unknown as EventEmitter).on('exit', () => {
+    previews.delete(workspaceId);
+    prisma.workspaceRuntime
+      .updateMany({ where: { workspaceId }, data: { previewUrl: null } })
+      .catch(() => undefined);
+  });
+
+  previews.set(workspaceId, { process: vite, port, previewUrl });
+
+  await prisma.workspaceRuntime
+    .updateMany({ where: { workspaceId }, data: { previewUrl } })
+    .catch((err) => {
+      console.warn(`[preview ${workspaceId}] failed to persist previewUrl:`, err);
+    });
+
+  return previewUrl;
+}
+
+/**
+ * Stop the preview server for a workspace. No-ops if not running.
+ */
+export function stopPreview(workspaceId: string): void {
+  const entry = previews.get(workspaceId);
+  if (!entry) return;
+  previews.delete(workspaceId);
+  entry.process.kill('SIGTERM');
+}
+
+export function getPreviewUrl(workspaceId: string): string | null {
+  return previews.get(workspaceId)?.previewUrl ?? null;
+}

--- a/packages/backend/src/lib/pty-manager.ts
+++ b/packages/backend/src/lib/pty-manager.ts
@@ -1,0 +1,174 @@
+/**
+ * Per-workspace PTY session manager.
+ *
+ * Spawns a `node-pty` pseudoterminal for each workspace, persists the session
+ * ID to `workspaceRuntime.terminalSessionId`, and provides attach/detach/resize
+ * helpers consumed by the WebSocket terminal endpoint.
+ *
+ * At most one PTY session exists per workspace at a time.
+ */
+
+import pty from 'node-pty';
+import { randomUUID } from 'node:crypto';
+import { prisma } from './prisma';
+import { workspaceHostPath } from './workspace-fs';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type PtyDataListener = (data: string) => void;
+export type PtyExitListener = (exitCode: number) => void;
+
+export type PtySession = {
+  sessionId: string;
+  workspaceId: string;
+  cols: number;
+  rows: number;
+  cwd: string;
+  startedAt: number;
+  /** Write input to the PTY. */
+  write: (data: string) => void;
+  /** Resize the PTY. */
+  resize: (cols: number, rows: number) => void;
+  /** Subscribe to data output from the PTY. */
+  onData: (listener: PtyDataListener) => () => void;
+  /** Subscribe to PTY exit. */
+  onExit: (listener: PtyExitListener) => () => void;
+  /** Kill the PTY and clean up. */
+  kill: () => void;
+};
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+/** One session per workspace. */
+const sessions = new Map<string, PtySession>();
+/** workspaceId → sessionId reverse index. */
+const workspaceIndex = new Map<string, string>();
+
+const DEFAULT_COLS = 120;
+const DEFAULT_ROWS = 30;
+
+const SHELL = process.env['SHELL'] ?? '/bin/bash';
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Create (or return existing) PTY session for a workspace. Persists the
+ * session ID to the database.
+ */
+export async function getOrCreatePtySession(
+  workspaceId: string,
+  opts?: { cols?: number; rows?: number },
+): Promise<PtySession> {
+  const existingId = workspaceIndex.get(workspaceId);
+  if (existingId) {
+    const existing = sessions.get(existingId);
+    if (existing) return existing;
+  }
+
+  const sessionId = `pty-${randomUUID()}`;
+  const cwd = workspaceHostPath(workspaceId);
+  const cols = opts?.cols ?? DEFAULT_COLS;
+  const rows = opts?.rows ?? DEFAULT_ROWS;
+
+  const proc = pty.spawn(SHELL, [], {
+    name: 'xterm-256color',
+    cols,
+    rows,
+    cwd,
+    env: {
+      ...process.env,
+      TERM: 'xterm-256color',
+      WORKSPACE_ID: workspaceId,
+    },
+  });
+
+  const dataListeners = new Set<PtyDataListener>();
+  const exitListeners = new Set<PtyExitListener>();
+
+  proc.onData((data) => {
+    for (const listener of dataListeners) {
+      try {
+        listener(data);
+      } catch {
+        // Misbehaving listener must not crash the PTY.
+      }
+    }
+  });
+
+  proc.onExit(({ exitCode }) => {
+    sessions.delete(sessionId);
+    workspaceIndex.delete(workspaceId);
+    for (const listener of exitListeners) {
+      try {
+        listener(exitCode ?? 0);
+      } catch {
+        // Ignore.
+      }
+    }
+  });
+
+  const session: PtySession = {
+    sessionId,
+    workspaceId,
+    cols,
+    rows,
+    cwd,
+    startedAt: Date.now(),
+    write: (data) => proc.write(data),
+    resize: (c, r) => {
+      session.cols = c;
+      session.rows = r;
+      proc.resize(c, r);
+    },
+    onData: (listener) => {
+      dataListeners.add(listener);
+      return () => dataListeners.delete(listener);
+    },
+    onExit: (listener) => {
+      exitListeners.add(listener);
+      return () => exitListeners.delete(listener);
+    },
+    kill: () => {
+      proc.kill();
+      sessions.delete(sessionId);
+      workspaceIndex.delete(workspaceId);
+    },
+  };
+
+  sessions.set(sessionId, session);
+  workspaceIndex.set(workspaceId, sessionId);
+
+  // Persist the session ID to the runtime row so the frontend can discover it.
+  await prisma.workspaceRuntime
+    .updateMany({
+      where: { workspaceId },
+      data: { terminalSessionId: sessionId },
+    })
+    .catch((err) => {
+      console.warn(`[pty ${sessionId}] failed to persist sessionId to DB:`, err);
+    });
+
+  return session;
+}
+
+export function getPtySession(sessionId: string): PtySession | undefined {
+  return sessions.get(sessionId);
+}
+
+export function getPtySessionByWorkspace(workspaceId: string): PtySession | undefined {
+  const id = workspaceIndex.get(workspaceId);
+  return id ? sessions.get(id) : undefined;
+}
+
+export function cleanupWorkspacePty(workspaceId: string): void {
+  const id = workspaceIndex.get(workspaceId);
+  if (id) {
+    sessions.get(id)?.kill();
+  }
+}

--- a/packages/backend/src/lib/runtime-docker.ts
+++ b/packages/backend/src/lib/runtime-docker.ts
@@ -144,6 +144,16 @@ function workspaceBind(workspaceId: string, hostWorkspacePath: string): string {
     ? path.join(WORKSPACES_BIND_ROOT, workspaceId)
     : hostWorkspacePath;
 
+  // Docker treats a non-absolute bind source as a named-volume name, which
+  // silently disconnects the agent's file writes from the workspace container.
+  // Refuse to create such a container — surface the misconfiguration loudly.
+  if (!path.isAbsolute(bindSource)) {
+    throw new Error(
+      `workspace bind source must be an absolute path (got "${bindSource}"). ` +
+        `Set CRUCIBLE_WORKSPACES_ROOT or CRUCIBLE_RUNTIME_BIND_ROOT to an absolute path.`,
+    );
+  }
+
   return `${bindSource}:/workspace`;
 }
 

--- a/packages/backend/src/lib/runtime-docker.ts
+++ b/packages/backend/src/lib/runtime-docker.ts
@@ -405,6 +405,9 @@ export async function ensureWorkspaceContainer(
             `WORKSPACE_ID=${workspaceId}`,
             `CHAIN_MCP_PORT=${CONTAINER_CHAIN_PORT}`,
             `COMPILER_MCP_PORT=${CONTAINER_COMPILER_PORT}`,
+            `DEPLOYER_MCP_PORT=${CONTAINER_DEPLOYER_PORT}`,
+            `WALLET_MCP_PORT=${CONTAINER_WALLET_PORT}`,
+            `MEMORY_MCP_PORT=${CONTAINER_MEMORY_PORT}`,
             `WORKSPACE_ROOT=${workspaceDir}`,
           ],
           ExposedPorts: {

--- a/packages/backend/src/lib/runtime-docker.ts
+++ b/packages/backend/src/lib/runtime-docker.ts
@@ -29,6 +29,10 @@ const WORKSPACES_VOLUME = process.env['CRUCIBLE_WORKSPACES_VOLUME'] ?? 'crucible
 // assigned dynamically by Docker and discovered after the container starts.
 const CONTAINER_CHAIN_PORT = 3100;
 const CONTAINER_COMPILER_PORT = 3101;
+const CONTAINER_DEPLOYER_PORT = 3102;
+const CONTAINER_WALLET_PORT = 3103;
+const CONTAINER_MEMORY_PORT = 3104;
+const CONTAINER_TERMINAL_PORT = 3105;
 
 const READINESS_TIMEOUT_MS = Number(process.env['CRUCIBLE_RUNTIME_READY_TIMEOUT_MS'] ?? '60000');
 const READINESS_INTERVAL_MS = Number(process.env['CRUCIBLE_RUNTIME_READY_INTERVAL_MS'] ?? '500');
@@ -298,6 +302,10 @@ export async function stopWorkspaceContainer(workspaceId: string): Promise<void>
 export type WorkspaceRuntimePorts = {
   chain: number | null;
   compiler: number | null;
+  deployer: number | null;
+  wallet: number | null;
+  memory: number | null;
+  terminal: number | null;
 };
 
 export type EnsureWorkspaceContainerResult = {
@@ -392,6 +400,10 @@ export async function ensureWorkspaceContainer(
           ExposedPorts: {
             [`${CONTAINER_CHAIN_PORT}/tcp`]: {},
             [`${CONTAINER_COMPILER_PORT}/tcp`]: {},
+            [`${CONTAINER_DEPLOYER_PORT}/tcp`]: {},
+            [`${CONTAINER_WALLET_PORT}/tcp`]: {},
+            [`${CONTAINER_MEMORY_PORT}/tcp`]: {},
+            [`${CONTAINER_TERMINAL_PORT}/tcp`]: {},
           },
           HostConfig: {
             RestartPolicy: { Name: 'unless-stopped' },
@@ -400,6 +412,10 @@ export async function ensureWorkspaceContainer(
             PortBindings: {
               [`${CONTAINER_CHAIN_PORT}/tcp`]: [{ HostPort: '' }],
               [`${CONTAINER_COMPILER_PORT}/tcp`]: [{ HostPort: '' }],
+              [`${CONTAINER_DEPLOYER_PORT}/tcp`]: [{ HostPort: '' }],
+              [`${CONTAINER_WALLET_PORT}/tcp`]: [{ HostPort: '' }],
+              [`${CONTAINER_MEMORY_PORT}/tcp`]: [{ HostPort: '' }],
+              [`${CONTAINER_TERMINAL_PORT}/tcp`]: [{ HostPort: '' }],
             },
           },
         }),
@@ -430,6 +446,10 @@ export async function ensureWorkspaceContainer(
   const ports: WorkspaceRuntimePorts = {
     chain: freshInspect ? extractHostPort(freshInspect, CONTAINER_CHAIN_PORT) : null,
     compiler: freshInspect ? extractHostPort(freshInspect, CONTAINER_COMPILER_PORT) : null,
+    deployer: freshInspect ? extractHostPort(freshInspect, CONTAINER_DEPLOYER_PORT) : null,
+    wallet: freshInspect ? extractHostPort(freshInspect, CONTAINER_WALLET_PORT) : null,
+    memory: freshInspect ? extractHostPort(freshInspect, CONTAINER_MEMORY_PORT) : null,
+    terminal: freshInspect ? extractHostPort(freshInspect, CONTAINER_TERMINAL_PORT) : null,
   };
 
   const ready = await waitForRuntimeReady(ports);
@@ -452,9 +472,13 @@ export async function getWorkspaceContainerPorts(
   return {
     chain: extractHostPort(inspect, CONTAINER_CHAIN_PORT),
     compiler: extractHostPort(inspect, CONTAINER_COMPILER_PORT),
+    deployer: extractHostPort(inspect, CONTAINER_DEPLOYER_PORT),
+    wallet: extractHostPort(inspect, CONTAINER_WALLET_PORT),
+    memory: extractHostPort(inspect, CONTAINER_MEMORY_PORT),
+    terminal: extractHostPort(inspect, CONTAINER_TERMINAL_PORT),
   };
 }
 
-export function runtimeServiceBaseUrl(_server: 'chain' | 'compiler', port: number): string {
+export function runtimeServiceBaseUrl(port: number): string {
   return `http://${RUNTIME_HOST}:${port}`;
 }

--- a/packages/backend/src/lib/tool-exec.ts
+++ b/packages/backend/src/lib/tool-exec.ts
@@ -5,9 +5,6 @@
  * The agent calls `POST /api/runtime` with `{type:'tool_exec', server, tool, args}`.
  * We resolve the captured host port for that workspace's service and forward
  * the request to its REST endpoint defined in `packages/mcp-{chain,compiler}`.
- *
- * Only `chain` and `compiler` are wired today (per Phase 0/1 issue #1 scope).
- * Other servers return a clean unsupported outcome.
  */
 
 import { getWorkspaceContainerPorts, runtimeServiceBaseUrl } from './runtime-docker';
@@ -16,7 +13,7 @@ type ToolExecInput = {
   tool: string;
   args: unknown;
   workspaceId: string;
-  server: 'chain' | 'compiler' | 'deployer' | 'wallet' | 'terminal';
+  server: 'chain' | 'compiler' | 'deployer' | 'wallet' | 'terminal' | 'memory' | 'mesh';
 };
 
 type ToolExecOutcome =
@@ -69,13 +66,39 @@ const COMPILER_ROUTES: Record<string, RouteSpec> = {
   },
 };
 
-function pickRoute(server: 'chain' | 'compiler', tool: string): RouteSpec | null {
-  const table = server === 'chain' ? CHAIN_ROUTES : COMPILER_ROUTES;
-  return table[tool] ?? null;
+const DEPLOYER_ROUTES: Record<string, RouteSpec> = {
+  deploy: { method: 'POST', path: () => '/deploy', withBody: true },
+  verify: { method: 'POST', path: () => '/verify', withBody: true },
+};
+
+const WALLET_ROUTES: Record<string, RouteSpec> = {
+  get_balance: { method: 'GET', path: () => '/balance', withBody: false },
+  send: { method: 'POST', path: () => '/send', withBody: true },
+};
+
+const MEMORY_ROUTES: Record<string, RouteSpec> = {
+  get: { method: 'GET', path: () => '/memory', withBody: false },
+  set: { method: 'POST', path: () => '/memory', withBody: true },
+};
+
+const MESH_ROUTES: Record<string, RouteSpec> = {};
+
+type KnownServer = 'chain' | 'compiler' | 'deployer' | 'wallet' | 'memory' | 'mesh';
+
+function pickRoute(server: KnownServer, tool: string): RouteSpec | null {
+  const tables: Record<KnownServer, Record<string, RouteSpec>> = {
+    chain: CHAIN_ROUTES,
+    compiler: COMPILER_ROUTES,
+    deployer: DEPLOYER_ROUTES,
+    wallet: WALLET_ROUTES,
+    memory: MEMORY_ROUTES,
+    mesh: MESH_ROUTES,
+  };
+  return tables[server][tool] ?? null;
 }
 
 async function proxyToService(
-  server: 'chain' | 'compiler',
+  server: string,
   port: number,
   spec: RouteSpec,
   args: Record<string, unknown>,
@@ -85,7 +108,7 @@ async function proxyToService(
     return { ok: false, error: `tool requires a non-empty contractName argument` };
   }
 
-  const url = `${runtimeServiceBaseUrl(server, port)}${path}`;
+  const url = `${runtimeServiceBaseUrl(port)}${path}`;
   const init: RequestInit = {
     method: spec.method,
     headers: spec.withBody
@@ -129,10 +152,10 @@ async function proxyToService(
 }
 
 export async function executeRuntimeTool(input: ToolExecInput): Promise<ToolExecOutcome> {
-  if (input.server !== 'chain' && input.server !== 'compiler') {
+  if (input.server === 'terminal') {
     return {
       ok: false,
-      error: `tool_exec server '${input.server}' is not implemented yet`,
+      error: `terminal interaction is handled via the WebSocket PTY endpoint, not tool_exec`,
     };
   }
 
@@ -144,7 +167,16 @@ export async function executeRuntimeTool(input: ToolExecInput): Promise<ToolExec
     };
   }
 
-  const port = input.server === 'chain' ? ports.chain : ports.compiler;
+  const portMap: Record<string, number | null> = {
+    chain: ports.chain,
+    compiler: ports.compiler,
+    deployer: ports.deployer,
+    wallet: ports.wallet,
+    memory: ports.memory,
+    mesh: null,
+  };
+
+  const port = portMap[input.server] ?? null;
   if (port === null) {
     return {
       ok: false,
@@ -152,7 +184,7 @@ export async function executeRuntimeTool(input: ToolExecInput): Promise<ToolExec
     };
   }
 
-  const spec = pickRoute(input.server, input.tool);
+  const spec = pickRoute(input.server as KnownServer, input.tool);
   if (!spec) {
     return {
       ok: false,

--- a/packages/backend/src/lib/tool-exec.ts
+++ b/packages/backend/src/lib/tool-exec.ts
@@ -67,18 +67,39 @@ const COMPILER_ROUTES: Record<string, RouteSpec> = {
 };
 
 const DEPLOYER_ROUTES: Record<string, RouteSpec> = {
-  deploy: { method: 'POST', path: () => '/deploy', withBody: true },
-  verify: { method: 'POST', path: () => '/verify', withBody: true },
+  deploy_local: { method: 'POST', path: () => '/deploy_local', withBody: true },
+  simulate_local: { method: 'POST', path: () => '/simulate_local', withBody: true },
+  trace: { method: 'POST', path: () => '/trace', withBody: true },
+  call: { method: 'POST', path: () => '/call', withBody: true },
 };
 
 const WALLET_ROUTES: Record<string, RouteSpec> = {
-  get_balance: { method: 'GET', path: () => '/balance', withBody: false },
-  send: { method: 'POST', path: () => '/send', withBody: true },
+  list_accounts: { method: 'GET', path: () => '/accounts', withBody: false },
+  get_balance: {
+    method: 'GET',
+    path: (args) => {
+      const address = typeof args['address'] === 'string' ? args['address'] : '';
+      return address ? `/balance/${encodeURIComponent(address)}` : null;
+    },
+    withBody: false,
+  },
+  sign_tx: { method: 'POST', path: () => '/sign_tx', withBody: true },
+  send_tx_local: { method: 'POST', path: () => '/send_tx_local', withBody: true },
+  switch_account: { method: 'POST', path: () => '/switch_account', withBody: true },
 };
 
 const MEMORY_ROUTES: Record<string, RouteSpec> = {
-  get: { method: 'GET', path: () => '/memory', withBody: false },
-  set: { method: 'POST', path: () => '/memory', withBody: true },
+  recall: { method: 'POST', path: () => '/recall', withBody: true },
+  remember: { method: 'POST', path: () => '/remember', withBody: true },
+  list_patterns: { method: 'GET', path: () => '/patterns', withBody: false },
+  provenance: {
+    method: 'GET',
+    path: (args) => {
+      const id = typeof args['id'] === 'string' ? args['id'] : '';
+      return id ? `/provenance/${encodeURIComponent(id)}` : null;
+    },
+    withBody: false,
+  },
 };
 
 const MESH_ROUTES: Record<string, RouteSpec> = {};

--- a/packages/backend/src/lib/workspace-fs.ts
+++ b/packages/backend/src/lib/workspace-fs.ts
@@ -1,9 +1,10 @@
 import path from 'node:path';
 import { createHash } from 'node:crypto';
-import { mkdir, readdir, readFile, stat } from 'node:fs/promises';
+import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { WorkspaceFileLangSchema, type WorkspaceFile } from '@crucible/types';
 
 const WORKSPACES_ROOT = process.env['CRUCIBLE_WORKSPACES_ROOT'] ?? '/var/lib/crucible/workspaces';
+const MAX_FILE_SIZE_BYTES = 512 * 1024; // 512 KiB — skip large binaries/generated files
 
 export function workspaceHostPath(workspaceId: string): string {
   return path.join(WORKSPACES_ROOT, workspaceId);
@@ -12,9 +13,178 @@ export function workspaceHostPath(workspaceId: string): string {
 export async function provisionWorkspaceDirectory(workspaceId: string): Promise<string> {
   const workspaceDir = workspaceHostPath(workspaceId);
   await mkdir(path.join(workspaceDir, 'contracts'), { recursive: true });
-  await mkdir(path.join(workspaceDir, 'frontend'), { recursive: true });
+  await mkdir(path.join(workspaceDir, 'frontend', 'src'), { recursive: true });
   await mkdir(path.join(workspaceDir, '.crucible'), { recursive: true });
+
+  // Write the React + Vite + wagmi/viem template if the frontend has not yet
+  // been initialised (i.e. package.json does not exist).
+  await scaffoldFrontend(path.join(workspaceDir, 'frontend'));
+
   return workspaceDir;
+}
+
+// ---------------------------------------------------------------------------
+// React + Vite + wagmi/viem scaffold
+// ---------------------------------------------------------------------------
+
+async function writeIfAbsent(filePath: string, content: string): Promise<void> {
+  try {
+    await stat(filePath); // exists → skip
+  } catch {
+    await writeFile(filePath, content, 'utf8');
+  }
+}
+
+async function scaffoldFrontend(frontendDir: string): Promise<void> {
+  const pkg = {
+    name: 'crucible-preview',
+    version: '0.0.0',
+    private: true,
+    type: 'module',
+    scripts: { dev: 'vite', build: 'tsc -b && vite build', preview: 'vite preview' },
+    dependencies: {
+      react: '^19.1.0',
+      'react-dom': '^19.1.0',
+      viem: '^2.31.3',
+      wagmi: '^2.15.6',
+      '@tanstack/react-query': '^5.74.4',
+    },
+    devDependencies: {
+      '@types/react': '^19.1.0',
+      '@types/react-dom': '^19.1.0',
+      '@vitejs/plugin-react': '^4.4.1',
+      typescript: '^5.8.3',
+      vite: '^6.3.4',
+    },
+  };
+
+  await writeIfAbsent(path.join(frontendDir, 'package.json'), JSON.stringify(pkg, null, 2) + '\n');
+
+  await writeIfAbsent(
+    path.join(frontendDir, 'vite.config.ts'),
+    `import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: { strictPort: true },
+});
+`,
+  );
+
+  await writeIfAbsent(
+    path.join(frontendDir, 'tsconfig.json'),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: 'ES2020',
+          lib: ['ES2020', 'DOM', 'DOM.Iterable'],
+          module: 'ESNext',
+          skipLibCheck: true,
+          moduleResolution: 'bundler',
+          allowImportingTsExtensions: true,
+          isolatedModules: true,
+          moduleDetection: 'force',
+          noEmit: true,
+          jsx: 'react-jsx',
+          strict: true,
+        },
+        include: ['src'],
+      },
+      null,
+      2,
+    ) + '\n',
+  );
+
+  await writeIfAbsent(
+    path.join(frontendDir, 'index.html'),
+    `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Crucible Preview</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+`,
+  );
+
+  await writeIfAbsent(
+    path.join(frontendDir, 'src', 'config.ts'),
+    `import { http, createConfig } from 'wagmi';
+import { foundry } from 'wagmi/chains';
+
+export const config = createConfig({
+  chains: [foundry],
+  transports: {
+    [foundry.id]: http('http://localhost:8545'),
+  },
+});
+`,
+  );
+
+  await writeIfAbsent(
+    path.join(frontendDir, 'src', 'main.tsx'),
+    `import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { WagmiProvider } from 'wagmi';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { config } from './config';
+import App from './App';
+
+const queryClient = new QueryClient();
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <WagmiProvider config={config}>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </WagmiProvider>
+  </StrictMode>,
+);
+`,
+  );
+
+  await writeIfAbsent(
+    path.join(frontendDir, 'src', 'App.tsx'),
+    `import { useAccount, useConnect, useDisconnect, useBalance } from 'wagmi';
+
+export default function App() {
+  const { address, isConnected } = useAccount();
+  const { connect, connectors } = useConnect();
+  const { disconnect } = useDisconnect();
+  const { data: balance } = useBalance({ address });
+
+  return (
+    <div style={{ fontFamily: 'monospace', padding: '2rem' }}>
+      <h1>Crucible Preview</h1>
+      {isConnected ? (
+        <div>
+          <p>Connected: {address}</p>
+          {balance && (
+            <p>Balance: {balance.formatted} {balance.symbol}</p>
+          )}
+          <button onClick={() => disconnect()}>Disconnect</button>
+        </div>
+      ) : (
+        <div>
+          {connectors.map((connector) => (
+            <button key={connector.id} onClick={() => connect({ connector })}>
+              Connect {connector.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+`,
+  );
 }
 
 function detectWorkspaceFileLang(filePath: string) {
@@ -22,7 +192,9 @@ function detectWorkspaceFileLang(filePath: string) {
   const byExt: Record<string, string> = {
     '.sol': 'solidity',
     '.ts': 'typescript',
+    '.tsx': 'typescript',
     '.js': 'javascript',
+    '.jsx': 'javascript',
     '.svelte': 'svelte',
     '.json': 'json',
     '.css': 'css',
@@ -31,6 +203,38 @@ function detectWorkspaceFileLang(filePath: string) {
     '.txt': 'plaintext',
   };
   return WorkspaceFileLangSchema.parse(byExt[ext] ?? 'plaintext');
+}
+
+/**
+ * Write `content` to a workspace-relative `filePath`, creating parent
+ * directories as needed.  Validates that the resolved path stays within the
+ * workspace root (defense-in-depth on top of schema-level `..` blocks).
+ */
+export async function writeWorkspaceFile(
+  workspaceId: string,
+  filePath: string,
+  content: string,
+): Promise<WorkspaceFile> {
+  const workspaceDir = workspaceHostPath(workspaceId);
+  const resolved = path.resolve(workspaceDir, filePath);
+
+  // Path traversal guard.
+  if (!resolved.startsWith(workspaceDir + path.sep) && resolved !== workspaceDir) {
+    throw new Error('Path escapes the workspace directory');
+  }
+
+  await mkdir(path.dirname(resolved), { recursive: true });
+  const encoded = Buffer.from(content, 'utf8');
+  await writeFile(resolved, encoded);
+  const fileStats = await stat(resolved);
+
+  return {
+    path: filePath,
+    content,
+    lang: detectWorkspaceFileLang(filePath),
+    hash: createHash('sha256').update(encoded).digest('hex'),
+    modifiedAt: Math.trunc(fileStats.mtimeMs),
+  };
 }
 
 export async function collectWorkspaceFiles(workspaceDir: string): Promise<WorkspaceFile[]> {
@@ -42,8 +246,8 @@ export async function collectWorkspaceFiles(workspaceDir: string): Promise<Works
     for (const entry of entries) {
       const fullPath = path.join(currentDir, entry.name);
       if (entry.isDirectory()) {
-        // Skip build-output and dependency directories — not source files.
-        if (entry.name === '.crucible' || entry.name === 'node_modules') {
+        // Skip build-output, dependency, and version-control directories.
+        if (entry.name === '.crucible' || entry.name === 'node_modules' || entry.name === '.git') {
           continue;
         }
         await walk(fullPath);
@@ -54,8 +258,12 @@ export async function collectWorkspaceFiles(workspaceDir: string): Promise<Works
         continue;
       }
 
-      const raw = await readFile(fullPath);
       const fileStats = await stat(fullPath);
+      if (fileStats.size > MAX_FILE_SIZE_BYTES) {
+        continue;
+      }
+
+      const raw = await readFile(fullPath);
       files.push({
         path: path.relative(workspaceDir, fullPath).split(path.sep).join('/'),
         content: raw.toString('utf8'),

--- a/packages/backend/src/lib/workspace-fs.ts
+++ b/packages/backend/src/lib/workspace-fs.ts
@@ -3,7 +3,13 @@ import { createHash } from 'node:crypto';
 import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { WorkspaceFileLangSchema, type WorkspaceFile } from '@crucible/types';
 
-const WORKSPACES_ROOT = process.env['CRUCIBLE_WORKSPACES_ROOT'] ?? '/var/lib/crucible/workspaces';
+// Resolve to an absolute host path. An empty / unset env var must NOT be
+// allowed to fall through as a relative path — Docker bind mounts require
+// absolute paths, otherwise the source string is treated as a named-volume
+// name and the agent's file writes never reach the workspace container.
+const WORKSPACES_ROOT = path.resolve(
+  process.env['CRUCIBLE_WORKSPACES_ROOT']?.trim() || '/var/lib/crucible/workspaces',
+);
 const MAX_FILE_SIZE_BYTES = 512 * 1024; // 512 KiB — skip large binaries/generated files
 
 export function workspaceHostPath(workspaceId: string): string {

--- a/packages/backend/src/lib/workspace-fs.ts
+++ b/packages/backend/src/lib/workspace-fs.ts
@@ -209,13 +209,18 @@ function detectWorkspaceFileLang(filePath: string) {
  * Write `content` to a workspace-relative `filePath`, creating parent
  * directories as needed.  Validates that the resolved path stays within the
  * workspace root (defense-in-depth on top of schema-level `..` blocks).
+ *
+ * @param overrideDir - Use this directory instead of the default
+ *   `workspaceHostPath(workspaceId)`. Pass the DB-stored `directoryPath` when
+ *   available so the two sources of truth stay consistent.
  */
 export async function writeWorkspaceFile(
   workspaceId: string,
   filePath: string,
   content: string,
+  overrideDir?: string,
 ): Promise<WorkspaceFile> {
-  const workspaceDir = workspaceHostPath(workspaceId);
+  const workspaceDir = overrideDir ?? workspaceHostPath(workspaceId);
   const resolved = path.resolve(workspaceDir, filePath);
 
   // Path traversal guard.

--- a/packages/backend/test/helpers.ts
+++ b/packages/backend/test/helpers.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared test utilities: sign in anonymously through the real better-auth
+ * handler so the session token is in exactly the format the middleware expects.
+ */
+
+import { auth } from '../src/lib/auth';
+import { prisma } from '../src/lib/prisma';
+
+export interface TestSession {
+  userId: string;
+  /** Value to pass as the Cookie header: `better-auth.session_token=<signed-token>` */
+  cookie: string;
+}
+
+/**
+ * Sign in anonymously via the better-auth handler and return the userId and
+ * ready-to-use cookie string.
+ *
+ * Better-auth uses signed cookies (token.HMAC_SIGNATURE). We MUST use the
+ * Set-Cookie value from the response — not the raw token in the JSON body —
+ * because auth.api.getSession verifies the HMAC before looking up the session.
+ *
+ * Call `deleteTestUser(session.userId)` in afterEach/afterAll to clean up;
+ * cascades to sessions and workspaces.
+ */
+export async function createTestSession(): Promise<TestSession> {
+  const response = await auth.handler(
+    new Request(
+      `${process.env['BETTER_AUTH_URL'] ?? 'http://localhost:5000'}/api/auth/sign-in/anonymous`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      },
+    ),
+  );
+
+  // Read body first (consuming the stream), then inspect headers.
+  const body = (await response.json()) as Record<string, unknown>;
+
+  if (!response.ok) {
+    throw new Error(`Anonymous sign-in failed: ${response.status} — ${JSON.stringify(body)}`);
+  }
+
+  const user = body['user'] as { id: string } | undefined;
+  if (!user?.id) {
+    throw new Error(`No user in sign-in response: ${JSON.stringify(body)}`);
+  }
+
+  // Extract the SIGNED cookie value from Set-Cookie.
+  // Bun 1.x supports getSetCookie(); fall back to parsing get('set-cookie').
+  const setCookies: string[] =
+    (response.headers as unknown as { getSetCookie?: () => string[] }).getSetCookie?.() ??
+    (response.headers.get('set-cookie') ?? '').split(/,\s*(?=[^;]+(?:;|$))/);
+
+  let signedCookieValue: string | undefined;
+  for (const raw of setCookies) {
+    const match = raw.match(/^better-auth\.session_token=([^;]+)/);
+    if (match?.[1]) {
+      signedCookieValue = match[1].trim();
+      break;
+    }
+  }
+
+  if (!signedCookieValue) {
+    throw new Error(
+      `Session cookie not set in sign-in response. Set-Cookie: ${setCookies.join(' | ')}`,
+    );
+  }
+
+  return {
+    userId: user.id,
+    cookie: `better-auth.session_token=${signedCookieValue}`,
+  };
+}
+
+/**
+ * Delete the test user and all their data (sessions, workspaces) via cascade.
+ */
+export async function deleteTestUser(userId: string): Promise<void> {
+  await prisma.user.delete({ where: { id: userId } }).catch(() => undefined);
+}

--- a/packages/backend/test/runtime.test.ts
+++ b/packages/backend/test/runtime.test.ts
@@ -6,22 +6,32 @@
  * will fail gracefully if Docker is unavailable rather than being skipped.
  */
 
-import { describe, it, expect, afterEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { runtimeApi } from '../src/api/runtime';
+import { createTestSession, deleteTestUser, type TestSession } from './helpers';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-const createdWorkspaceIds: string[] = [];
+let session: TestSession;
+
+beforeEach(async () => {
+  session = await createTestSession();
+});
+
+afterEach(async () => {
+  // Cascade deletes sessions, workspaces, and runtime rows.
+  await deleteTestUser(session.userId);
+});
 
 async function postRuntime(body: unknown) {
   return runtimeApi.request('/runtime', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', Cookie: session.cookie },
     body: JSON.stringify(body),
   });
 }
 
-/** Create a workspace row directly via Prisma for runtime tests. */
+/** Create a workspace row owned by the current test user. */
 async function createTestWorkspace(name: string): Promise<string> {
   const { prisma } = await import('../src/lib/prisma');
   const { randomUUID } = await import('node:crypto');
@@ -30,20 +40,12 @@ async function createTestWorkspace(name: string): Promise<string> {
       name,
       directoryPath: `pending://${randomUUID()}`,
       deployments: [],
+      userId: session.userId,
     },
     select: { id: true },
   });
-  createdWorkspaceIds.push(workspace.id);
   return workspace.id;
 }
-
-afterEach(async () => {
-  const { prisma } = await import('../src/lib/prisma');
-  for (const id of createdWorkspaceIds.splice(0)) {
-    await prisma.workspaceRuntime.deleteMany({ where: { workspaceId: id } }).catch(() => undefined);
-    await prisma.workspace.delete({ where: { id } }).catch(() => undefined);
-  }
-});
 
 // ── Validation (no DB/Docker required) ───────────────────────────────────────
 
@@ -98,6 +100,18 @@ describe('POST /runtime — runtime_status', () => {
     expect(body.type).toBe('runtime_status');
     expect(body.correlationId).toBe('corr-status-1');
     expect(Array.isArray(body.descriptors)).toBe(true);
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    const res = await runtimeApi.request('/runtime', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'runtime_status', correlationId: 'corr-unauth' }),
+    });
+    expect(res.status).toBe(401);
+
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe('unauthorized');
   });
 });
 

--- a/packages/backend/test/setup.ts
+++ b/packages/backend/test/setup.ts
@@ -14,9 +14,10 @@ import { afterAll } from 'bun:test';
 // Default to the devcontainer Postgres service. Override via DATABASE_URL.
 process.env['DATABASE_URL'] ??= 'postgresql://postgres:postgres@localhost:5432/crucible';
 
-// ── Auth stubs (not exercised by route tests, but lib/auth.ts is not imported
-//    when testing sub-apps directly) ─────────────────────────────────────────
+// ── Auth stubs ───────────────────────────────────────────────────────────────
 process.env['BETTER_AUTH_URL'] ??= 'http://localhost:5000';
+process.env['BETTER_AUTH_SECRET'] ??=
+  'crucible-test-secret-not-for-productionet-not-for-production';
 process.env['GOOGLE_CLIENT_ID'] ??= 'test-client-id';
 process.env['GOOGLE_CLIENT_SECRET'] ??= 'test-client-secret';
 

--- a/packages/backend/test/workspace.test.ts
+++ b/packages/backend/test/workspace.test.ts
@@ -5,32 +5,37 @@
  * workspace and cleans up after itself so tests are fully isolated.
  */
 
-import { describe, it, expect, afterEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { workspaceApi } from '../src/api/workspace';
+import { createTestSession, deleteTestUser, type TestSession } from './helpers';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-const createdIds: string[] = [];
+let session: TestSession;
+
+beforeEach(async () => {
+  session = await createTestSession();
+});
+
+afterEach(async () => {
+  // Deleting the user cascades to sessions and workspaces.
+  await deleteTestUser(session.userId);
+});
 
 async function post(path: string, body: unknown) {
   return workspaceApi.request(path, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', Cookie: session.cookie },
     body: JSON.stringify(body),
   });
 }
 
 async function get(path: string) {
-  return workspaceApi.request(path, { method: 'GET' });
+  return workspaceApi.request(path, {
+    method: 'GET',
+    headers: { Cookie: session.cookie },
+  });
 }
-
-afterEach(async () => {
-  // Best-effort cleanup: delete any workspaces created during the test.
-  const { prisma } = await import('../src/lib/prisma');
-  for (const id of createdIds.splice(0)) {
-    await prisma.workspace.delete({ where: { id } }).catch(() => undefined);
-  }
-});
 
 // ── POST /workspace ──────────────────────────────────────────────────────────
 
@@ -42,8 +47,18 @@ describe('POST /workspace', () => {
     const body = (await res.json()) as { id: string };
     expect(typeof body.id).toBe('string');
     expect(body.id.length).toBeGreaterThan(0);
+  });
 
-    createdIds.push(body.id);
+  it('returns 401 when not authenticated', async () => {
+    const res = await workspaceApi.request('/workspace', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'unauth-test' }),
+    });
+    expect(res.status).toBe(401);
+
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe('unauthorized');
   });
 
   it('returns 400 for an empty name', async () => {
@@ -73,7 +88,7 @@ describe('POST /workspace', () => {
   it('returns 400 for a non-JSON body', async () => {
     const res = await workspaceApi.request('/workspace', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', Cookie: session.cookie },
       body: 'not json',
     });
     expect(res.status).toBe(400);
@@ -84,7 +99,6 @@ describe('POST /workspace', () => {
     expect(res.status).toBe(201);
 
     const { id } = (await res.json()) as { id: string };
-    createdIds.push(id);
 
     const { existsSync } = await import('node:fs');
     const workspacesRoot = process.env['CRUCIBLE_WORKSPACES_ROOT']!;
@@ -101,7 +115,6 @@ describe('GET /workspace/:id', () => {
     const createRes = await post('/workspace', { name: 'get-test' });
     expect(createRes.status).toBe(201);
     const { id } = (await createRes.json()) as { id: string };
-    createdIds.push(id);
 
     const res = await get(`/workspace/${id}`);
     expect(res.status).toBe(200);
@@ -118,6 +131,14 @@ describe('GET /workspace/:id', () => {
     expect(Array.isArray(body.files)).toBe(true);
     expect(Array.isArray(body.deployments)).toBe(true);
     expect(body.chainState).toBeNull();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    const res = await workspaceApi.request('/workspace/some-workspace-id', { method: 'GET' });
+    expect(res.status).toBe(401);
+
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe('unauthorized');
   });
 
   it('returns 404 for an unknown but validly-formatted id', async () => {
@@ -140,7 +161,6 @@ describe('GET /workspace/:id', () => {
     const createRes = await post('/workspace', { name: 'files-test' });
     expect(createRes.status).toBe(201);
     const { id } = (await createRes.json()) as { id: string };
-    createdIds.push(id);
 
     const res = await get(`/workspace/${id}`);
     expect(res.status).toBe(200);

--- a/packages/mcp-compiler/src/compiler.ts
+++ b/packages/mcp-compiler/src/compiler.ts
@@ -143,6 +143,8 @@ export async function compileSolidity(
         },
       },
     }),
+    undefined,
+    sourcesDir, // projectRoot — prevents Hardhat from defaulting to process.cwd()
   );
 
   const buildResult = await hre.solidity.build([normalizedAbsolutePath]);

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -15,7 +15,7 @@ import {
   StreamIdSchema,
   WorkspaceIdSchema,
 } from './primitives.ts';
-import { WorkspaceStateSchema } from './workspace.ts';
+import { WorkspaceStateSchema, WorkspaceFileSchema } from './workspace.ts';
 import { KeeperHubExecutionSchema } from './ship.ts';
 
 // --- POST /api/workspace -----------------------------------------------------
@@ -36,6 +36,24 @@ export type WorkspaceCreateResponse = z.infer<typeof WorkspaceCreateResponseSche
 /** Response is `WorkspaceState` from `./workspace.ts`. */
 export const WorkspaceGetResponseSchema = WorkspaceStateSchema;
 export type WorkspaceGetResponse = z.infer<typeof WorkspaceGetResponseSchema>;
+
+// --- PUT /api/workspace/:id/file ---------------------------------------------
+
+export const FileWriteRequestSchema = z.object({
+  /** Workspace-relative POSIX path (e.g. `contracts/Vault.sol`). Must not contain `..`. */
+  path: z
+    .string()
+    .min(1)
+    .max(512)
+    .refine((p) => !p.includes('..') && !p.startsWith('/'), {
+      message: 'path must be relative and must not contain ..',
+    }),
+  content: z.string().max(512 * 1024),
+});
+export type FileWriteRequest = z.infer<typeof FileWriteRequestSchema>;
+
+export const FileWriteResponseSchema = WorkspaceFileSchema;
+export type FileWriteResponse = z.infer<typeof FileWriteResponseSchema>;
 
 // --- POST /api/prompt --------------------------------------------------------
 

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -76,8 +76,8 @@ export const ToolExecRequestSchema = z.object({
   ...corr,
   type: z.literal('tool_exec'),
   workspaceId: WorkspaceIdSchema,
-  /** Logical MCP server name: `chain` | `compiler` | `deployer` | `wallet` | `terminal`. */
-  server: z.enum(['chain', 'compiler', 'deployer', 'wallet', 'terminal']),
+  /** Logical MCP server name: `chain` | `compiler` | `deployer` | `wallet` | `terminal` | `memory` | `mesh`. */
+  server: z.enum(['chain', 'compiler', 'deployer', 'wallet', 'terminal', 'memory', 'mesh']),
   tool: z.string().min(1),
   args: z.unknown(),
 });


### PR DESCRIPTION
## Summary

Implements the full backend control plane required for POV-1 (Inspectable Local Build Loop). All changes pass `turbo run lint check-types` with 0 errors across all 6 packages.

---

## Changes

### `@crucible/types`
- Add `FileWriteRequest` / `FileWriteResponse` schemas for `PUT /api/workspace/:id/file`
- Extend `ToolExecRequest.server` enum with `memory` and `mesh` options

### Prisma schema
- Add `userId` foreign key + `User` relation to `Workspace` model
- Add index on `Workspace.userId`
- Add `workspaces` back-relation on `User`

### Runtime Dockerfile
- Expose `DEPLOYER_MCP_PORT=3102`, `WALLET_MCP_PORT=3103`, `MEMORY_MCP_PORT=3104`, `TERMINAL_MCP_PORT=3105`

### `@crucible/agent` (new package)
- Streaming agentic loop using `ai@6` + `@ai-sdk/openai@3`
- Reads agent config (model, system prompt, tool definitions) from workspace filesystem
- Calls backend `tool-exec` endpoint for each MCP tool invocation
- Emits SSE events: `text-delta`, `tool-call`, `tool-result`, `usage`, `done`, `error`

### Backend — new infrastructure
| File | Purpose |
|---|---|
| `src/api/terminal.ts` | WebSocket endpoint for PTY-backed terminal sessions |
| `src/lib/pty-manager.ts` | `node-pty` lifecycle management per workspace |
| `src/lib/preview-manager.ts` | Vite dev-server proxy for in-workspace dApp previews |
| `src/lib/og-adapter.ts` | 0G serving-broker adapter for verifiable AI inference |

### Backend — control plane APIs
| Endpoint | What it does |
|---|---|
| `PUT /api/workspace/:id/file` | Write a file into a workspace (path-traversal guarded) |
| `POST /api/runtime/:id/start` | Pull image + start workspace Docker container |
| `POST /api/runtime/:id/stop` | Stop and remove container |
| `POST /api/agent/:id/run` | Start agentic loop, return SSE stream |
| `GET /api/agent/:id/stream` | Re-attach to an existing agent SSE stream |
| `POST /api/inference` | Proxy LLM call through 0G verifiable-inference |
| `POST /api/tool-exec` | Dispatch MCP tool call to runtime container |
| `WS /terminal/:id` | Open PTY terminal in workspace container |

### Supporting libs
- `agent-bus.ts` — in-memory pub/sub fan-out for streaming agent events
- `runtime-docker.ts` — Dockerode helpers (image pull, create/start/exec/logs)
- `tool-exec.ts` — HTTP dispatch to MCP servers running inside workspace containers
- `workspace-fs.ts` — host-path–scoped filesystem helpers

---

## Commit breakdown

```
feat(types): add file-write API types and memory/mesh MCP servers
feat(prisma): link workspaces to users
feat(runtime): expose deployer, wallet, memory, and terminal MCP ports
feat(agent): add @crucible/agent package with AI SDK v6 agentic loop
feat(backend): add terminal WebSocket, PTY, preview, and 0G adapter infrastructure
feat(backend): implement control plane APIs for workspaces, runtime, agent, and inference
chore: update bun.lock for new dependencies
```

---

## Test status

- `turbo run lint` — 6/6 ✅
- `turbo run check-types` — 6/6 ✅ (0 errors, 14 vendored warnings in `ai-elements`)
