### PR TITLE
feat: implement mcp-deployer, mcp-wallet, and mcp-memory services and APIs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -170,6 +170,23 @@
         "typescript": "^5.7.3",
       },
     },
+    "packages/mcp-memory": {
+      "name": "@crucible/mcp-memory",
+      "version": "0.0.0",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "@crucible/types": "workspace:*",
+        "@hono/zod-openapi": "^1.3.0",
+        "@modelcontextprotocol/hono": "2.0.0-alpha.2",
+        "@modelcontextprotocol/server": "2.0.0-alpha.2",
+        "hono": "^4.0.0",
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.6",
+        "typescript": "^5.7.3",
+      },
+    },
     "packages/mcp-wallet": {
       "name": "@crucible/mcp-wallet",
       "version": "0.0.0",
@@ -291,6 +308,8 @@
     "@crucible/mcp-compiler": ["@crucible/mcp-compiler@workspace:packages/mcp-compiler"],
 
     "@crucible/mcp-deployer": ["@crucible/mcp-deployer@workspace:packages/mcp-deployer"],
+
+    "@crucible/mcp-memory": ["@crucible/mcp-memory@workspace:packages/mcp-memory"],
 
     "@crucible/mcp-wallet": ["@crucible/mcp-wallet@workspace:packages/mcp-wallet"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -153,6 +153,23 @@
         "typescript": "^5.7.3",
       },
     },
+    "packages/mcp-deployer": {
+      "name": "@crucible/mcp-deployer",
+      "version": "0.0.0",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "@crucible/types": "workspace:*",
+        "@hono/zod-openapi": "^1.3.0",
+        "@modelcontextprotocol/hono": "2.0.0-alpha.2",
+        "@modelcontextprotocol/server": "2.0.0-alpha.2",
+        "hono": "^4.0.0",
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.6",
+        "typescript": "^5.7.3",
+      },
+    },
     "packages/types": {
       "name": "@crucible/types",
       "version": "0.0.0",
@@ -255,6 +272,8 @@
     "@crucible/mcp-chain": ["@crucible/mcp-chain@workspace:packages/mcp-chain"],
 
     "@crucible/mcp-compiler": ["@crucible/mcp-compiler@workspace:packages/mcp-compiler"],
+
+    "@crucible/mcp-deployer": ["@crucible/mcp-deployer@workspace:packages/mcp-deployer"],
 
     "@crucible/types": ["@crucible/types@workspace:packages/types"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -170,6 +170,23 @@
         "typescript": "^5.7.3",
       },
     },
+    "packages/mcp-wallet": {
+      "name": "@crucible/mcp-wallet",
+      "version": "0.0.0",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "@crucible/types": "workspace:*",
+        "@hono/zod-openapi": "^1.3.0",
+        "@modelcontextprotocol/hono": "2.0.0-alpha.2",
+        "@modelcontextprotocol/server": "2.0.0-alpha.2",
+        "hono": "^4.0.0",
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.6",
+        "typescript": "^5.7.3",
+      },
+    },
     "packages/types": {
       "name": "@crucible/types",
       "version": "0.0.0",
@@ -274,6 +291,8 @@
     "@crucible/mcp-compiler": ["@crucible/mcp-compiler@workspace:packages/mcp-compiler"],
 
     "@crucible/mcp-deployer": ["@crucible/mcp-deployer@workspace:packages/mcp-deployer"],
+
+    "@crucible/mcp-wallet": ["@crucible/mcp-wallet@workspace:packages/mcp-wallet"],
 
     "@crucible/types": ["@crucible/types@workspace:packages/types"],
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -240,16 +240,16 @@ Each workspace also gets its own isolated Hardhat process and snapshot stack. Th
 
 The agent's power comes from **eight MCP servers** — seven custom + KeeperHub's — that give it deep chain awareness, persistent memory, a peer mesh, and shared terminal/runtime control. All custom MCP servers run on the backend, communicate with the agent over HTTP, and accept Zod-validated tool arguments.
 
-| MCP Server        | Port       | Tools                                                                               | Purpose                                                                               |
-| :---------------- | :--------- | :---------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------ |
-| **chain-mcp**     | 3100       | `start_node`, `get_state`, `snapshot`, `revert`, `mine`, `fork`                     | Manage the local chain lifecycle and state                                            |
-| **compiler-mcp**  | 3101       | `compile`, `get_abi`, `get_bytecode`, `list_contracts`                              | Compile Solidity source files or inline source strings, extract artifacts             |
-| **deployer-mcp**  | 3102       | `deploy_local`, `simulate_local`, `trace`, `call`                                   | Deploy contracts, simulate & trace transactions locally                               |
-| **wallet-mcp**    | 3103       | `list_accounts`, `get_balance`, `sign_tx`, `send_tx_local`, `switch_account`        | Manage accounts and sign/send transactions                                            |
-| **memory-mcp**    | 3104       | `recall`, `remember`, `list_patterns`, `provenance`                                 | Store and retrieve learned debugging patterns on 0G Storage                           |
-| **mesh-mcp**      | 3105       | `list_peers`, `broadcast_help`, `collect_responses`, `respond`, `verify_peer_patch` | Discover peer Crucible nodes and exchange fix candidates over AXL                     |
-| **terminal-mcp**  | 3106       | `create_session`, `write`, `exec`, `resize`                                         | Own PTY-backed shell sessions and make terminal output visible to both user and agent |
-| **KeeperHub MCP** | (external) | `simulate_bundle`, `estimate_gas`, `execute_tx`, `get_execution_status`             | Production-grade tx execution — the only path to public chains                        |
+| MCP Server        | Port       | Tools                                                                               | Purpose                                                                                                       |
+| :---------------- | :--------- | :---------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------ |
+| **chain-mcp**     | 3100       | `start_node`, `get_state`, `snapshot`, `revert`, `mine`, `fork`                     | Manage the local chain lifecycle and state                                                                    |
+| **compiler-mcp**  | 3101       | `compile`, `get_abi`, `get_bytecode`, `list_contracts`                              | Compile Solidity source files, extract artifacts                                                              |
+| **deployer-mcp**  | 3102       | `deploy_local`, `simulate_local`, `trace`, `call`                                   | Deploy compiled contracts by name, simulate & trace transactions locally                                      |
+| **wallet-mcp**    | 3103       | `list_accounts`, `get_balance`, `sign_tx`, `send_tx_local`, `switch_account`        | Manage accounts and sign/send transactions                                                                    |
+| **memory-mcp**    | 3104       | `recall`, `remember`, `list_patterns`, `provenance`                                 | Store and retrieve learned debugging patterns on 0G Storage                                                   |
+| **mesh-mcp**      | 3105       | `list_peers`, `broadcast_help`, `collect_responses`, `respond`, `verify_peer_patch` | Discover peer Crucible nodes and exchange fix candidates over AXL _(planned)_                                 |
+| **terminal-mcp**  | 3106       | `create_session`, `write`, `exec`, `resize`                                         | Own PTY-backed shell sessions and make terminal output visible to both user and agent _(planned)_ _(planned)_ |
+| **KeeperHub MCP** | (external) | `simulate_bundle`, `estimate_gas`, `execute_tx`, `get_execution_status`             | Production-grade tx execution — the only path to public chains                                                |
 
 ### chain-mcp — Implementation Notes
 
@@ -259,9 +259,9 @@ The agent's power comes from **eight MCP servers** — seven custom + KeeperHub'
 
 ### compiler-mcp — Implementation Notes
 
-- **compile** accepts either a `sourcePath` (absolute path to a `.sol` file on disk) or an inline `source` string, with an optional `fileName` (defaults to `Inline.sol`). Exactly one of the two must be provided; passing both or neither is a validation error.
-- Inline source is written to a temporary directory, compiled, then cleaned up. Artifacts are only persisted to `.crucible/artifacts/` when a real workspace `sourcePath` is used.
+- **compile** accepts a `sourcePath` — a workspace-relative path to a `.sol` file on disk (e.g. `"contracts/Counter.sol"`). Artifacts are always persisted to `.crucible/artifacts/`.
 - **ALLOWED_HOSTS**: same as chain-mcp — required for remote access.
+- **COMPILER_URL**: `mcp-deployer` reads this env var (default `http://localhost:3101`) to fetch bytecode from compiler-mcp when `deploy_local` is called by contract namep://localhost:3101`) to fetch bytecode from compiler-mcp when `deploy_local` is called by contract name.
 
 ---
 
@@ -365,10 +365,12 @@ list_contracts(): { contracts: string[] }
 
 ```typescript
 // Tools (local Hardhat only — public-chain deploys go through KeeperHub MCP)
-deploy_local(bytecode, constructorArgs?, sender?): { address, txHash, gasUsed }
+// Requires the contract to have been compiled via compiler-mcp first.
+deploy_local(contractName: string, constructorData: Hex, sender?: Address, value?: bigint): { address, txHash, gasUsed }
 simulate_local(txObject): { result, gasEstimate, logs, revertReason? }
-trace(txHash): { structLogs, decodedCalls, storageReads, storageWrites, revertReason? }
-call(to, functionSig, args?): { result }
+trace(txHash): { decodedCalls, storageReads, storageWrites, events, revertReason?, gasUsed }
+call(to: Address, data: Hex, from?: Addressls, storageReads, storageWrites, events, revertReason?, gasUsed }
+call(to: Address, data: Hex, from?: Address): { result }
 ```
 
 ### wallet-mcp
@@ -827,7 +829,7 @@ If the fallback path was used, the UI also shows that the current inference prov
 
 **What actually happens underneath:**
 
-- `deployer-mcp` reads bytecode from artifacts and deploys to the workspace Hardhat process
+- `deployer-mcp` fetches bytecode by contract name from compiler-mcp's artifact store and deploys to the workspace Hardhat process
 - `wallet-mcp` supplies the active dev account
 - Deployment metadata is appended to `.crucible/state.json`
 - Preview uses its EIP-1193 bridge to send approved JSON-RPC requests through the parent shell to that specific workspace chain

--- a/packages/backend/src/lib/tool-exec.ts
+++ b/packages/backend/src/lib/tool-exec.ts
@@ -16,7 +16,7 @@ type ToolExecInput = {
   tool: string;
   args: unknown;
   workspaceId: string;
-  server: 'chain' | 'compiler' | 'deployer' | 'wallet' | 'terminal';
+  server: 'chain' | 'compiler' | 'deployer' | 'wallet' | 'terminal' | 'memory' | 'mesh';
 };
 
 type ToolExecOutcome =

--- a/packages/mcp-chain/src/index.ts
+++ b/packages/mcp-chain/src/index.ts
@@ -315,6 +315,38 @@ app.openapi(forkRoute, async (c) => {
   }
 });
 
+// JSON-RPC proxy — forwards raw JSON-RPC requests to the active Hardhat node.
+// mcp-wallet and mcp-deployer use this as their CHAIN_RPC_URL (port 3100/rpc).
+app.post('/rpc', async (c) => {
+  let node;
+  try {
+    node = requireNode(WORKSPACE_ID);
+  } catch {
+    return c.json(
+      {
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32000, message: 'No active node — call start_node first' },
+      },
+      503,
+    );
+  }
+  const body = c.get('parsedBody');
+  if (!body) {
+    return c.json(
+      { jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } },
+      400,
+    );
+  }
+  const upstream = await fetch(node.rpcUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = await upstream.json();
+  return c.json(data, upstream.status as 200);
+});
+
 // MCP protocol endpoint (hidden from OpenAPI spec).
 app.all('/mcp', (c) => transport.handleRequest(c.req.raw, { parsedBody: c.get('parsedBody') }));
 

--- a/packages/mcp-compiler/src/index.ts
+++ b/packages/mcp-compiler/src/index.ts
@@ -17,8 +17,7 @@ import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/
 import { hostHeaderValidation } from '@modelcontextprotocol/hono';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { writeFile, mkdir, rm } from 'node:fs/promises';
-import { randomUUID } from 'node:crypto';
+
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
 import { z } from 'zod';
 import { mcp } from '@crucible/types';
@@ -163,40 +162,23 @@ app.use('*', async (c, next) => {
 
 // REST route handlers
 app.openapi(compileRoute, async (c) => {
-  let tempDir: string | undefined;
   try {
-    const { sourcePath, source, fileName, settings } = c.req.valid('json');
-    let absolutePath: string;
+    const { sourcePath, settings } = c.req.valid('json');
+    console.log(`[mcp-compiler] compile path=${sourcePath}`);
+    const absolutePath = join(WORKSPACE_ROOT, sourcePath);
     let rel: string;
-
-    if (source !== undefined) {
-      const solFileName = fileName ?? 'Inline.sol';
-      console.log(
-        `[mcp-compiler] compile inline=${solFileName} (${source.split('\n').length} lines)`,
-      );
-      tempDir = join(WORKSPACE_ROOT, '.crucible', 'tmp', `inline-${randomUUID()}`);
-      await mkdir(tempDir, { recursive: true });
-      absolutePath = join(tempDir, solFileName);
-      await writeFile(absolutePath, source, 'utf8');
-      rel = `<inline>/${solFileName}`;
-    } else {
-      console.log(`[mcp-compiler] compile path=${sourcePath}`);
-      absolutePath = join(WORKSPACE_ROOT, sourcePath!);
-      try {
-        rel = await assertContainedInWorkspace(WORKSPACE_ROOT, absolutePath);
-      } catch (e) {
-        console.error(`[mcp-compiler] compile error: ${String(e)}`);
-        return c.json({ error: String(e) }, 400);
-      }
+    try {
+      rel = await assertContainedInWorkspace(WORKSPACE_ROOT, absolutePath);
+    } catch (e) {
+      console.error(`[mcp-compiler] compile error: ${String(e)}`);
+      return c.json({ error: String(e) }, 400);
     }
     const result = await compileSolidity(absolutePath, {
       version: SOLC_VERSION,
       ...(settings ?? {}),
     } as SolcSettings);
     store.storeContracts(result.contracts, rel);
-    if (!tempDir) {
-      await store.persistArtifacts(WORKSPACE_ROOT, result.contracts);
-    }
+    await store.persistArtifacts(WORKSPACE_ROOT, result.contracts);
     const seen = new Set<string>();
     const topWarnings = (result.warnings ?? []).filter((w) => {
       if (seen.has(w.message)) return false;
@@ -217,10 +199,6 @@ app.openapi(compileRoute, async (c) => {
   } catch (err) {
     console.error(`[mcp-compiler] compile error: ${String(err)}`);
     return c.json({ error: String(err) }, 500);
-  } finally {
-    if (tempDir) {
-      await rm(tempDir, { recursive: true, force: true });
-    }
   }
 });
 

--- a/packages/mcp-compiler/src/server.ts
+++ b/packages/mcp-compiler/src/server.ts
@@ -37,12 +37,18 @@ export async function assertContainedInWorkspace(
   workspaceRoot: string,
   candidatePath: string,
 ): Promise<string> {
-  const [resolvedRoot, resolvedCandidate] = await Promise.all([
-    realpath(workspaceRoot),
-    // candidatePath may not exist yet; fall back to the un-resolved path so
-    // compilation errors surface from solc rather than from path validation.
-    realpath(candidatePath).catch(() => candidatePath),
-  ]);
+  const resolvedRoot = await realpath(workspaceRoot);
+  let resolvedCandidate: string;
+  try {
+    resolvedCandidate = await realpath(candidatePath);
+  } catch {
+    // File doesn't exist yet. Swap the raw workspaceRoot prefix for the
+    // resolved root so symlink differences (e.g. /tmp → /private/tmp on macOS)
+    // don't cause a false "outside workspace" rejection.
+    resolvedCandidate = candidatePath.startsWith(workspaceRoot)
+      ? resolvedRoot + candidatePath.slice(workspaceRoot.length)
+      : candidatePath;
+  }
   const rel = relative(resolvedRoot, resolvedCandidate);
   if (rel.startsWith('..') || isAbsolute(rel)) {
     throw new Error('sourcePath must resolve within the workspace root');

--- a/packages/mcp-compiler/src/server.ts
+++ b/packages/mcp-compiler/src/server.ts
@@ -6,8 +6,7 @@
  */
 
 import { join, relative, isAbsolute } from 'node:path';
-import { realpath, writeFile, mkdir, rm } from 'node:fs/promises';
-import { randomUUID } from 'node:crypto';
+import { realpath } from 'node:fs/promises';
 import { McpServer, type CallToolResult } from '@modelcontextprotocol/server';
 import {
   CompileInputSchema,
@@ -82,11 +81,10 @@ export function createCompilerServer(opts: {
     {
       title: 'Compile Solidity',
       description:
-        'Compile a Solidity contract. Provide either:\n' +
-        '  • sourcePath — workspace-relative path of an existing .sol file, OR\n' +
-        '  • source    — inline Solidity source code (string); use fileName to set the .sol name.\n' +
-        'Exactly one of sourcePath/source must be supplied. Passing both is an error.\n' +
-        'Stores artifacts in-process for subsequent get_abi / get_bytecode calls. ' +
+        'Compile a Solidity source file from the workspace. ' +
+        'Provide sourcePath as a workspace-relative path to an existing .sol file ' +
+        '(e.g. "contracts/Counter.sol"). ' +
+        'Stores artifacts in-process for subsequent get_abi / get_bytecode / deploy_local calls. ' +
         'Returns all contracts found in the file, along with any compiler warnings.',
       inputSchema: CompileInputSchema,
       annotations: {
@@ -96,41 +94,23 @@ export function createCompilerServer(opts: {
         openWorldHint: false,
       },
     },
-    async ({ sourcePath, source, fileName, settings }: CompileInput) => {
-      let tempDir: string | undefined;
+    async ({ sourcePath, settings }: CompileInput) => {
       try {
-        let absolutePath: string;
+        log(`tool:compile path=${sourcePath}`);
+        const absolutePath = join(opts.workspaceRoot, sourcePath);
         let rel: string;
-
-        if (source !== undefined) {
-          // Inline source — write inside the workspace so Hardhat's project-root
-          // boundary check passes (files outside the project root are rejected).
-          const solFileName = fileName ?? 'Inline.sol';
-          log(`tool:compile inline=${solFileName} (${source.split('\n').length} lines)`);
-          tempDir = join(opts.workspaceRoot, '.crucible', 'tmp', `inline-${randomUUID()}`);
-          await mkdir(tempDir, { recursive: true });
-          absolutePath = join(tempDir, solFileName);
-          await writeFile(absolutePath, source, 'utf8');
-          rel = `<inline>/${solFileName}`;
-        } else {
-          log(`tool:compile path=${sourcePath}`);
-          absolutePath = join(opts.workspaceRoot, sourcePath!);
-          try {
-            rel = await assertContainedInWorkspace(opts.workspaceRoot, absolutePath);
-          } catch (e) {
-            logError(`tool:compile error: ${String(e)}`);
-            return errorResult(`compile failed: ${String(e)}`);
-          }
+        try {
+          rel = await assertContainedInWorkspace(opts.workspaceRoot, absolutePath);
+        } catch (e) {
+          logError(`tool:compile error: ${String(e)}`);
+          return errorResult(`compile failed: ${String(e)}`);
         }
         const result = await compileSolidity(absolutePath, {
           version: opts.solcVersion,
           ...(settings ?? {}),
         } as SolcSettings);
         store.storeContracts(result.contracts, rel);
-        // Only persist artifacts to disk for workspace files, not inline source.
-        if (!tempDir) {
-          await store.persistArtifacts(opts.workspaceRoot, result.contracts);
-        }
+        await store.persistArtifacts(opts.workspaceRoot, result.contracts);
 
         // Deduplicate warnings by message text and surface them at the top level
         // so the agent sees a clean summary without iterating over every contract.
@@ -155,10 +135,6 @@ export function createCompilerServer(opts: {
       } catch (err) {
         logError(`tool:compile error: ${String(err)}`);
         return errorResult(`compile failed: ${String(err)}`);
-      } finally {
-        if (tempDir) {
-          await rm(tempDir, { recursive: true, force: true });
-        }
       }
     },
   );
@@ -280,30 +256,25 @@ export function createCompilerServer(opts: {
               'You are connected to the crucible-compiler MCP server, which compiles Solidity source files.',
               '',
               'Typical workflow:',
-              '1. Call compile to compile a Solidity contract. Two modes:',
-              '   a) File mode: pass sourcePath (workspace-relative, e.g. "src/Counter.sol")',
-              '   b) Inline mode: pass source (raw Solidity code as a string) and optionally',
-              '      fileName (e.g. "Counter.sol") to control the artifact identifier.',
-              '   Only one of sourcePath or source may be provided — passing both is an error.',
-              '   Returns a list of contract names found in the file, plus any compiler warnings.',
-              '   Artifacts are cached in-process for the lifetime of the server.',
+              '1. Call compile(sourcePath) — a workspace-relative path to a .sol file',
+              '   (e.g. "contracts/Counter.sol"). Returns contract names and any warnings.',
+              '   Artifacts (ABI, bytecode) are persisted to .crucible/artifacts/.',
               '2. Call list_contracts to see all currently cached contract names.',
-              '3. Call get_abi with the contract name to retrieve its ABI.',
-              '   - The ABI is required by deployment and interaction tools.',
-              '4. Call get_bytecode with the contract name to retrieve creation + deployed bytecode.',
-              '   - Use creation bytecode when sending a deployment transaction.',
+              '3. Call get_abi(contractName) to retrieve the ABI.',
+              '   - Required by front-end clients and interaction tools.',
+              "4. Call get_bytecode for inspection only. crucible-deployer's deploy_local",
+              '   fetches bytecode automatically by contract name.',
               '',
               'Tool reference:',
-              '  compile        — Compile a .sol file or inline source; returns contract names and warnings.',
+              '  compile        — Compile a workspace .sol file; returns contract names and warnings.',
               '  list_contracts — Read-only: list all cached contract names.',
               '  get_abi        — Read-only: get the ABI for a compiled contract.',
               '  get_bytecode   — Read-only: get creation and deployed bytecode.',
               '',
               'Notes:',
-              '  - sourcePath must be relative to the workspace root, not an absolute path.',
-              '  - Inline source (source field) is compiled in a temp directory and not persisted.',
-              '  - Artifact cache is reset when the server restarts.',
-              '  - Recompile a file to pick up source changes.',
+              '  - sourcePath must be workspace-relative, not absolute.',
+              '  - Artifacts survive server restarts (stored on disk).',
+              '  - Recompile to pick up source changes.',
             ].join('\n'),
           },
         },
@@ -316,7 +287,7 @@ export function createCompilerServer(opts: {
     {
       title: 'Compile & Deploy Contract',
       description:
-        'End-to-end guide: compile a Solidity contract, retrieve its artifacts, then deploy it using the chain server.',
+        'End-to-end guide: compile a Solidity contract then deploy it via crucible-deployer.',
     },
     () => ({
       messages: [
@@ -325,22 +296,22 @@ export function createCompilerServer(opts: {
           content: {
             type: 'text' as const,
             text: [
-              'End-to-end deployment flow using both crucible-compiler and crucible-chain:',
+              'End-to-end deployment flow using crucible-compiler, crucible-chain, and crucible-deployer:',
               '',
-              '1. [compiler] compile the source file → note the contract name.',
-              '2. [compiler] get_abi  → save the ABI for later interaction.',
-              '3. [compiler] get_bytecode → get creation bytecode for the deploy tx.',
-              '4. [chain]    start_node → ensure a local EVM node is running.',
-              '5. [chain]    get_state → pick a funded account from the accounts list.',
-              '6. [chain]    snapshot → save state before deployment.',
-              '7. Deploy by sending an eth_sendTransaction (or equivalent) with:',
-              '     from: <funded account>',
-              '     data: <creation bytecode>',
-              '     gas:  estimate via eth_estimateGas first.',
-              '8. Confirm deployment by calling eth_getTransactionReceipt.',
-              '9. Interact with the deployed contract using its ABI and the returned address.',
+              '1. [compiler] compile(sourcePath) → note the contract name(s) returned.',
+              '2. [compiler] get_abi(contractName) → save the ABI for later interaction.',
+              '3. [chain]    start_node → ensure a local EVM node is running.',
+              '4. [chain]    snapshot → save state before deployment.',
+              '5. [deployer] deploy_local(contractName, constructorData) → returns address and txHash.',
+              '   - constructorData is ABI-encoded constructor args ("0x" if none).',
+              '   - Bytecode is fetched automatically from the compiler artifact store.',
+              '   - Optionally pass sender (defaults to first local account) and value.',
+              '6. Interact with the deployed contract using its ABI and the returned address.',
+              '7. [chain]    revert(snapshotId) to roll back between test scenarios.',
               '',
-              'To test multiple deployment scenarios, call revert between each run.',
+              'Tips:',
+              '  - If deploy_local returns "Contract not found", run compile first.',
+              '  - Take a new snapshot after each successful deploy to create a clean baseline.',
             ].join('\n'),
           },
         },

--- a/packages/mcp-compiler/test/server.test.ts
+++ b/packages/mcp-compiler/test/server.test.ts
@@ -14,47 +14,29 @@ describe('createCompilerServer', () => {
   });
 });
 
-// ── CompileInputSchema — mutual exclusion ──────────────────────────────────
+// ── CompileInputSchema ─────────────────────────────────────────────────────
 
 describe('CompileInputSchema', () => {
   it('accepts sourcePath alone', () => {
-    const result = CompileInputSchema.safeParse({ sourcePath: '/workspace/Counter.sol' });
+    const result = CompileInputSchema.safeParse({ sourcePath: 'contracts/Counter.sol' });
     expect(result.success).toBe(true);
   });
 
-  it('accepts source alone', () => {
+  it('accepts sourcePath with optional settings', () => {
     const result = CompileInputSchema.safeParse({
-      source: '// SPDX-License-Identifier: MIT\npragma solidity ^0.8.0;\ncontract A {}',
+      sourcePath: 'contracts/Counter.sol',
+      settings: { optimizer: { enabled: true } },
     });
     expect(result.success).toBe(true);
   });
 
-  it('accepts source with an explicit fileName', () => {
-    const result = CompileInputSchema.safeParse({
-      source: '// SPDX-License-Identifier: MIT\npragma solidity ^0.8.0;\ncontract A {}',
-      fileName: 'MyToken.sol',
-    });
-    expect(result.success).toBe(true);
-  });
-
-  it('rejects when both sourcePath and source are provided', () => {
-    const result = CompileInputSchema.safeParse({
-      sourcePath: '/workspace/Counter.sol',
-      source: '// SPDX-License-Identifier: MIT\npragma solidity ^0.8.0;\ncontract A {}',
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it('rejects when neither sourcePath nor source are provided', () => {
+  it('rejects when sourcePath is missing', () => {
     const result = CompileInputSchema.safeParse({});
     expect(result.success).toBe(false);
   });
 
-  it('rejects a fileName that does not end in .sol', () => {
-    const result = CompileInputSchema.safeParse({
-      source: '// SPDX-License-Identifier: MIT\npragma solidity ^0.8.0;\ncontract A {}',
-      fileName: 'Token.ts',
-    });
+  it('rejects when sourcePath is empty', () => {
+    const result = CompileInputSchema.safeParse({ sourcePath: '' });
     expect(result.success).toBe(false);
   });
 });

--- a/packages/mcp-deployer/.env.example
+++ b/packages/mcp-deployer/.env.example
@@ -1,8 +1,8 @@
 # Port for deployer MCP HTTP server
 DEPLOYER_MCP_PORT=3102
 
-# Internal chain RPC endpoint (mcp-chain)
-CHAIN_RPC_URL=http://localhost:3100
+# Internal chain RPC endpoint (mcp-chain JSON-RPC proxy)
+CHAIN_RPC_URL=http://localhost:3100/rpc
 
 # Workspace root for path containment checks (if/when path inputs are used)
 WORKSPACE_ROOT=.

--- a/packages/mcp-deployer/.env.example
+++ b/packages/mcp-deployer/.env.example
@@ -1,0 +1,11 @@
+# Port for deployer MCP HTTP server
+DEPLOYER_MCP_PORT=3102
+
+# Internal chain RPC endpoint (mcp-chain)
+CHAIN_RPC_URL=http://localhost:3100
+
+# Workspace root for path containment checks (if/when path inputs are used)
+WORKSPACE_ROOT=.
+
+# Optional comma-separated extra allowed Host headers
+# ALLOWED_HOSTS=macbook,100.x.y.z

--- a/packages/mcp-deployer/package.json
+++ b/packages/mcp-deployer/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@crucible/mcp-deployer",
+  "version": "0.0.0",
+  "private": true,
+  "description": "MCP server — local-chain deploy, simulation, tracing, and read calls.",
+  "license": "UNLICENSED",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "dev": "portless --name deployer.crucible --app-port 3102 bun run --hot src/index.ts",
+    "start": "bun run src/index.ts",
+    "build": "echo 'Bun runtime — no compile step'",
+    "check-types": "tsc --noEmit",
+    "lint": "eslint .",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@cfworker/json-schema": "^4.1.1",
+    "@crucible/types": "workspace:*",
+    "@hono/zod-openapi": "^1.3.0",
+    "@modelcontextprotocol/hono": "2.0.0-alpha.2",
+    "@modelcontextprotocol/server": "2.0.0-alpha.2",
+    "hono": "^4.0.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.6",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/mcp-deployer/src/index.ts
+++ b/packages/mcp-deployer/src/index.ts
@@ -1,0 +1,272 @@
+/**
+ * mcp-deployer entry point.
+ *
+ * Starts an OpenAPIHono HTTP server on DEFAULT_MCP_PORTS.deployer (3102) or
+ * the port specified by DEPLOYER_MCP_PORT.
+ *
+ * Exposes both:
+ *   POST /mcp   — MCP protocol transport (hidden from OpenAPI docs)
+ *   REST routes — typed endpoints consumable via hc<AppType> from the frontend
+ *
+ * Environment flags:
+ *   DEPLOYER_MCP_PORT=N   — override the listen port
+ *   CHAIN_RPC_URL=<url>   — chain RPC endpoint (defaults to http://localhost:3100)
+ *   WORKSPACE_ROOT=<path> — workspace root for path checks (defaults to cwd)
+ */
+
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
+import { hostHeaderValidation } from '@modelcontextprotocol/hono';
+import { existsSync } from 'node:fs';
+import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
+import { z } from 'zod';
+import { mcp } from '@crucible/types';
+import {
+  DeployLocalInputSchema,
+  SimulateLocalInputSchema,
+  TraceInputSchema,
+  CallInputSchema,
+} from '@crucible/types/mcp/deployer';
+import { createDeployerServer } from './server.ts';
+import { createDeployerService } from './service.ts';
+
+const PORT = process.env['DEPLOYER_MCP_PORT']
+  ? parseInt(process.env['DEPLOYER_MCP_PORT'], 10)
+  : mcp.DEFAULT_MCP_PORTS.deployer;
+
+const CHAIN_RPC_URL = process.env['CHAIN_RPC_URL'] ?? 'http://localhost:3100';
+const WORKSPACE_ROOT = process.env['WORKSPACE_ROOT'] ?? process.cwd();
+
+console.log(
+  `[mcp-deployer] starting on port ${PORT} (workspaceRoot: ${WORKSPACE_ROOT}, chainRpcUrl: ${CHAIN_RPC_URL})`,
+);
+
+if (!existsSync(WORKSPACE_ROOT)) {
+  throw new Error(`[mcp-deployer] WORKSPACE_ROOT does not exist: ${WORKSPACE_ROOT}`);
+}
+
+const service = createDeployerService({
+  chainRpcUrl: CHAIN_RPC_URL,
+  workspaceRoot: WORKSPACE_ROOT,
+});
+
+const ErrorSchema = z.object({ error: z.string() });
+
+// Wire-format schemas (no branded/transformed outputs) for OpenAPI route typing.
+const DeployLocalOutputWireSchema = z.object({
+  address: z.string(),
+  txHash: z.string(),
+  gasUsed: z.string(),
+});
+
+const SimulateLocalOutputWireSchema = z.object({
+  result: z.string(),
+  gasEstimate: z.string(),
+  revertReason: z.string().optional(),
+  logs: z.array(
+    z.object({
+      address: z.string(),
+      topics: z.array(z.string()),
+      data: z.string(),
+    }),
+  ),
+});
+
+const TraceOutputWireSchema = z.object({
+  txHash: z.string(),
+  decodedCalls: z.array(
+    z.object({
+      depth: z.number().int().nonnegative(),
+      to: z.string(),
+      fn: z.string(),
+      args: z.array(z.unknown()),
+      result: z.unknown().nullable(),
+      reverted: z.boolean(),
+    }),
+  ),
+  storageReads: z.array(
+    z.object({
+      contract: z.string(),
+      slot: z.string(),
+      value: z.string(),
+    }),
+  ),
+  storageWrites: z.array(
+    z.object({
+      contract: z.string(),
+      slot: z.string(),
+      value: z.string(),
+    }),
+  ),
+  events: z.array(
+    z.object({
+      contract: z.string(),
+      name: z.string(),
+      args: z.record(z.string(), z.unknown()),
+      signatureHash: z.string(),
+    }),
+  ),
+  revertReason: z.string().optional(),
+  gasUsed: z.string(),
+});
+
+const CallOutputWireSchema = z.object({ result: z.string() });
+
+const deployLocalRoute = createRoute({
+  method: 'post',
+  path: '/deploy_local',
+  request: {
+    body: { content: { 'application/json': { schema: DeployLocalInputSchema } }, required: true },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: DeployLocalOutputWireSchema } },
+      description: 'Deployed locally',
+    },
+    500: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Error' },
+  },
+});
+
+const simulateLocalRoute = createRoute({
+  method: 'post',
+  path: '/simulate_local',
+  request: {
+    body: {
+      content: { 'application/json': { schema: SimulateLocalInputSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: SimulateLocalOutputWireSchema } },
+      description: 'Simulation result',
+    },
+    500: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Error' },
+  },
+});
+
+const traceRoute = createRoute({
+  method: 'post',
+  path: '/trace',
+  request: {
+    body: { content: { 'application/json': { schema: TraceInputSchema } }, required: true },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: TraceOutputWireSchema } },
+      description: 'Transaction trace',
+    },
+    500: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Error' },
+  },
+});
+
+const callRoute = createRoute({
+  method: 'post',
+  path: '/call',
+  request: {
+    body: { content: { 'application/json': { schema: CallInputSchema } }, required: true },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: CallOutputWireSchema } },
+      description: 'Read-only call result',
+    },
+    500: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Error' },
+  },
+});
+
+const mcpServer = createDeployerServer({
+  chainRpcUrl: CHAIN_RPC_URL,
+  workspaceRoot: WORKSPACE_ROOT,
+});
+
+type Env = { Variables: { parsedBody: unknown } };
+
+const transport = new WebStandardStreamableHTTPServerTransport();
+await mcpServer.connect(transport);
+
+const app = new OpenAPIHono<Env>();
+
+const extraHosts = process.env['ALLOWED_HOSTS']
+  ? process.env['ALLOWED_HOSTS']
+      .split(',')
+      .map((h) => h.trim())
+      .filter(Boolean)
+  : [];
+app.use('*', hostHeaderValidation(['localhost', '127.0.0.1', '::1', '[::1]', ...extraHosts]));
+
+app.use('*', async (c, next) => {
+  if (c.req.header('content-type')?.includes('application/json')) {
+    try {
+      c.set('parsedBody', await c.req.json<unknown>());
+    } catch {
+      // non-JSON or empty body
+    }
+  }
+  await next();
+});
+
+app.use('*', async (c, next) => {
+  const path = new URL(c.req.url).pathname;
+  if (path === '/doc') {
+    await next();
+    return;
+  }
+  const start = Date.now();
+  console.log(`[mcp-deployer] → ${c.req.method} ${path}`);
+  await next();
+  const ms = Date.now() - start;
+  const status = c.res?.status ?? 0;
+  const logFn = status >= 500 ? console.error : status >= 400 ? console.warn : console.log;
+  logFn(`[mcp-deployer] ← ${status} (${ms}ms)`);
+});
+
+app.openapi(deployLocalRoute, async (c) => {
+  try {
+    const output = await service.deployLocal(c.req.valid('json'));
+    return c.json(output, 200);
+  } catch (err) {
+    console.error(`[mcp-deployer] deploy_local error: ${String(err)}`);
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+app.openapi(simulateLocalRoute, async (c) => {
+  try {
+    const output = await service.simulateLocal(c.req.valid('json'));
+    return c.json(output, 200);
+  } catch (err) {
+    console.error(`[mcp-deployer] simulate_local error: ${String(err)}`);
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+app.openapi(traceRoute, async (c) => {
+  try {
+    const output = await service.trace(c.req.valid('json'));
+    return c.json(output, 200);
+  } catch (err) {
+    console.error(`[mcp-deployer] trace error: ${String(err)}`);
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+app.openapi(callRoute, async (c) => {
+  try {
+    const output = await service.call(c.req.valid('json'));
+    return c.json(output, 200);
+  } catch (err) {
+    console.error(`[mcp-deployer] call error: ${String(err)}`);
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+app.all('/mcp', (c) => transport.handleRequest(c.req.raw, { parsedBody: c.get('parsedBody') }));
+
+app.doc('/doc', { openapi: '3.0.0', info: { version: '0.0.0', title: 'crucible-deployer' } });
+
+export type AppType = typeof app;
+
+export default {
+  port: PORT,
+  fetch: app.fetch,
+};

--- a/packages/mcp-deployer/src/index.ts
+++ b/packages/mcp-deployer/src/index.ts
@@ -9,9 +9,10 @@
  *   REST routes — typed endpoints consumable via hc<AppType> from the frontend
  *
  * Environment flags:
- *   DEPLOYER_MCP_PORT=N   — override the listen port
- *   CHAIN_RPC_URL=<url>   — chain RPC endpoint (defaults to http://localhost:3100)
- *   WORKSPACE_ROOT=<path> — workspace root for path checks (defaults to cwd)
+ *   DEPLOYER_MCP_PORT=N    — override the listen port
+ *   CHAIN_RPC_URL=<url>    — chain RPC endpoint (defaults to http://localhost:3100/rpc)
+ *   COMPILER_URL=<url>     — compiler service URL (defaults to http://localhost:3101)
+ *   WORKSPACE_ROOT=<path>  — workspace root for path checks (defaults to cwd)
  */
 
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
@@ -33,11 +34,12 @@ const PORT = process.env['DEPLOYER_MCP_PORT']
   ? parseInt(process.env['DEPLOYER_MCP_PORT'], 10)
   : mcp.DEFAULT_MCP_PORTS.deployer;
 
-const CHAIN_RPC_URL = process.env['CHAIN_RPC_URL'] ?? 'http://localhost:3100';
+const CHAIN_RPC_URL = process.env['CHAIN_RPC_URL'] ?? 'http://localhost:3100/rpc';
+const COMPILER_URL = process.env['COMPILER_URL'] ?? 'http://localhost:3101';
 const WORKSPACE_ROOT = process.env['WORKSPACE_ROOT'] ?? process.cwd();
 
 console.log(
-  `[mcp-deployer] starting on port ${PORT} (workspaceRoot: ${WORKSPACE_ROOT}, chainRpcUrl: ${CHAIN_RPC_URL})`,
+  `[mcp-deployer] starting on port ${PORT} (workspaceRoot: ${WORKSPACE_ROOT}, chainRpcUrl: ${CHAIN_RPC_URL}, compilerUrl: ${COMPILER_URL})`,
 );
 
 if (!existsSync(WORKSPACE_ROOT)) {
@@ -47,6 +49,7 @@ if (!existsSync(WORKSPACE_ROOT)) {
 const service = createDeployerService({
   chainRpcUrl: CHAIN_RPC_URL,
   workspaceRoot: WORKSPACE_ROOT,
+  compilerUrl: COMPILER_URL,
 });
 
 const ErrorSchema = z.object({ error: z.string() });
@@ -177,6 +180,7 @@ const callRoute = createRoute({
 const mcpServer = createDeployerServer({
   chainRpcUrl: CHAIN_RPC_URL,
   workspaceRoot: WORKSPACE_ROOT,
+  compilerUrl: COMPILER_URL,
 });
 
 type Env = { Variables: { parsedBody: unknown } };

--- a/packages/mcp-deployer/src/server.ts
+++ b/packages/mcp-deployer/src/server.ts
@@ -32,6 +32,7 @@ function errorResult(message: string): CallToolResult {
 export function createDeployerServer(opts: {
   chainRpcUrl: string;
   workspaceRoot: string;
+  compilerUrl?: string;
 }): McpServer {
   const service = createDeployerService(opts);
   const server = new McpServer({
@@ -44,7 +45,10 @@ export function createDeployerServer(opts: {
     {
       title: 'Deploy Contract Locally',
       description:
-        'Deploy creation bytecode to the local chain via eth_sendTransaction and return address, tx hash, and gas used.',
+        'Deploy a compiled contract to the local chain by name. ' +
+        'Requires the contract to have been compiled first (run compile via compiler-mcp). ' +
+        'Bytecode is fetched automatically from the artifact store. ' +
+        'Returns contract address, tx hash, and gas used.',
       inputSchema: DeployLocalInputSchema,
       annotations: {
         destructiveHint: true,
@@ -140,6 +144,96 @@ export function createDeployerServer(opts: {
         return errorResult(`call failed: ${String(err)}`);
       }
     },
+  );
+
+  // ── prompts ────────────────────────────────────────────────────────────────
+
+  server.registerPrompt(
+    'deployer_workflow',
+    {
+      title: 'Deployer Workflow',
+      description:
+        'Guide for deploying compiled contracts, simulating transactions, and tracing reverts on the local chain.',
+    },
+    () => ({
+      messages: [
+        {
+          role: 'user' as const,
+          content: {
+            type: 'text' as const,
+            text: [
+              'You are connected to the crucible-deployer MCP server.',
+              '',
+              'Prerequisites: a running Hardhat node (start via crucible-chain) and at least one',
+              'compiled contract (compile via crucible-compiler).',
+              '',
+              'Typical workflow:',
+              '1. Call deploy_local(contractName, constructorData) to deploy a compiled contract.',
+              '   - contractName must match a contract compiled by crucible-compiler.',
+              '   - constructorData is the ABI-encoded constructor arguments ("0x" if none).',
+              '   - Returns { address, txHash, gasUsed }.',
+              '2. Call simulate_local(to, data, from?) to dry-run a call without mining.',
+              '   - Returns { result, gasEstimate, revertReason?, logs }.',
+              '   - Use before sending real transactions to detect reverts early.',
+              '3. Call call(to, data, from?) for read-only view/pure function calls.',
+              '4. Call trace(txHash) to get a decoded call trace for a mined transaction.',
+              '   - Returns decoded call frames, storage reads/writes, events, and revert reason.',
+              '',
+              'Tool reference:',
+              '  deploy_local    — Deploy a compiled contract by name; auto-fetches bytecode.',
+              '  simulate_local  — Dry-run a transaction (no state change).',
+              '  call            — Read-only eth_call.',
+              '  trace           — Debug trace a mined transaction.',
+              '',
+              'Notes:',
+              '  - If deploy_local fails with "Contract not found", run compile in crucible-compiler.',
+              '  - sender defaults to the first funded Hardhat account.',
+            ].join('\n'),
+          },
+        },
+      ],
+    }),
+  );
+
+  server.registerPrompt(
+    'debug_revert',
+    {
+      title: 'Debug a Revert',
+      description:
+        'Step-by-step guide for diagnosing transaction reverts using simulate and trace.',
+    },
+    () => ({
+      messages: [
+        {
+          role: 'user' as const,
+          content: {
+            type: 'text' as const,
+            text: [
+              'Debugging a revert with crucible-deployer:',
+              '',
+              'Option A — Before sending (preferred):',
+              '1. Call simulate_local with the same to, data, and from as your intended tx.',
+              '   - If it reverts, revertReason will contain the decoded error.',
+              '   - Fix the inputs or contract logic before proceeding.',
+              '',
+              'Option B — After a mined revert:',
+              '1. Get the txHash of the failed transaction.',
+              '2. Call trace(txHash) to get a full decoded call trace.',
+              '   - revertReason shows the innermost revert message.',
+              '   - decodedCalls shows the full call stack leading to the revert.',
+              '   - storageReads/storageWrites show exactly what state was touched.',
+              '',
+              'Option C — Pattern matching (with crucible-memory):',
+              '1. Take the revertReason from simulate or trace.',
+              '2. Call recall(query) in crucible-memory with the revert signature.',
+              '   - Returns previously verified fix patterns for similar errors.',
+              '3. Apply the suggested fix, re-simulate, and confirm the revert is gone.',
+              '4. Call remember(pattern) to persist the fix for future use.',
+            ].join('\n'),
+          },
+        },
+      ],
+    }),
   );
 
   return server;

--- a/packages/mcp-deployer/src/server.ts
+++ b/packages/mcp-deployer/src/server.ts
@@ -1,0 +1,146 @@
+import { McpServer, type CallToolResult } from '@modelcontextprotocol/server';
+import {
+  DeployLocalInputSchema,
+  SimulateLocalInputSchema,
+  TraceInputSchema,
+  CallInputSchema,
+  type DeployLocalInput,
+  type SimulateLocalInput,
+  type TraceInput,
+  type CallInput,
+} from '@crucible/types/mcp/deployer';
+import { createDeployerService } from './service.ts';
+
+const TAG = '[mcp-deployer]';
+const log = (msg: string) => console.log(`${TAG} ${msg}`);
+const logError = (msg: string) => console.error(`${TAG} ${msg}`);
+
+function toolResult(data: unknown): CallToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(data) }],
+    structuredContent: data as Record<string, unknown>,
+  };
+}
+
+function errorResult(message: string): CallToolResult {
+  return {
+    content: [{ type: 'text', text: message }],
+    isError: true,
+  };
+}
+
+export function createDeployerServer(opts: {
+  chainRpcUrl: string;
+  workspaceRoot: string;
+}): McpServer {
+  const service = createDeployerService(opts);
+  const server = new McpServer({
+    name: 'crucible-deployer',
+    version: '0.0.0',
+  });
+
+  server.registerTool(
+    'deploy_local',
+    {
+      title: 'Deploy Contract Locally',
+      description:
+        'Deploy creation bytecode to the local chain via eth_sendTransaction and return address, tx hash, and gas used.',
+      inputSchema: DeployLocalInputSchema,
+      annotations: {
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (input: DeployLocalInput) => {
+      try {
+        log('tool:deploy_local');
+        const output = await service.deployLocal(input);
+        log(`tool:deploy_local ok  address=${output.address} txHash=${output.txHash}`);
+        return toolResult(output);
+      } catch (err) {
+        logError(`tool:deploy_local error: ${String(err)}`);
+        return errorResult(`deploy_local failed: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'simulate_local',
+    {
+      title: 'Simulate Local Transaction',
+      description:
+        'Run eth_call + eth_estimateGas without mining and return call result, estimate, and optional revert reason.',
+      inputSchema: SimulateLocalInputSchema,
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (input: SimulateLocalInput) => {
+      try {
+        log('tool:simulate_local');
+        const output = await service.simulateLocal(input);
+        log(`tool:simulate_local ok  gasEstimate=${output.gasEstimate}`);
+        return toolResult(output);
+      } catch (err) {
+        logError(`tool:simulate_local error: ${String(err)}`);
+        return errorResult(`simulate_local failed: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'trace',
+    {
+      title: 'Trace Transaction',
+      description:
+        'Fetch debug trace for a transaction from Hardhat and return decoded call frames plus gas and optional revert reason.',
+      inputSchema: TraceInputSchema,
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (input: TraceInput) => {
+      try {
+        log(`tool:trace txHash=${input.txHash}`);
+        const output = await service.trace(input);
+        log(`tool:trace ok  gasUsed=${output.gasUsed}`);
+        return toolResult(output);
+      } catch (err) {
+        logError(`tool:trace error: ${String(err)}`);
+        return errorResult(`trace failed: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'call',
+    {
+      title: 'Read-only Contract Call',
+      description: 'Execute eth_call for read-only contract queries and return the raw hex result.',
+      inputSchema: CallInputSchema,
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (input: CallInput) => {
+      try {
+        log('tool:call');
+        const output = await service.call(input);
+        log('tool:call ok');
+        return toolResult(output);
+      } catch (err) {
+        logError(`tool:call error: ${String(err)}`);
+        return errorResult(`call failed: ${String(err)}`);
+      }
+    },
+  );
+
+  return server;
+}

--- a/packages/mcp-deployer/src/service.ts
+++ b/packages/mcp-deployer/src/service.ts
@@ -257,8 +257,31 @@ function callFramesToDecodedCalls(
 export function createDeployerService(opts: {
   chainRpcUrl: string;
   workspaceRoot: string;
+  compilerUrl?: string;
 }): DeployerService {
-  const { chainRpcUrl } = opts;
+  const { chainRpcUrl, compilerUrl = 'http://localhost:3101' } = opts;
+
+  /**
+   * Fetch contract bytecode from mcp-compiler.
+   * Throws if the contract is not found in the artifact store.
+   */
+  async function getCompiledBytecode(contractName: string): Promise<string> {
+    const res = await fetch(`${compilerUrl}/bytecode/${contractName}`);
+    if (!res.ok) {
+      if (res.status === 404) {
+        throw new Error(
+          `Contract "${contractName}" not found in artifact store — compile it first or provide raw bytecode`,
+        );
+      }
+      const text = await res.text().catch(() => '');
+      throw new Error(`Failed to fetch bytecode from compiler: ${res.status} ${text}`);
+    }
+    const data = (await res.json()) as { bytecode?: string };
+    if (!data.bytecode) {
+      throw new Error(`Compiler returned no bytecode for "${contractName}"`);
+    }
+    return data.bytecode;
+  }
 
   return {
     async deployLocal(input) {
@@ -269,7 +292,8 @@ export function createDeployerService(opts: {
           throw new Error('No local chain accounts available');
         })();
 
-      const data = `${input.bytecode}${input.constructorData.slice(2)}`;
+      const bytecode = await getCompiledBytecode(input.contractName);
+      const data = `${bytecode}${input.constructorData.slice(2)}`;
       const txHash = await rpc<string>(chainRpcUrl, 'eth_sendTransaction', [
         {
           from: sender,

--- a/packages/mcp-deployer/src/service.ts
+++ b/packages/mcp-deployer/src/service.ts
@@ -1,0 +1,369 @@
+import { isAbsolute, relative } from 'node:path';
+import { realpath } from 'node:fs/promises';
+import { encodeBigInt, type mcp } from '@crucible/types';
+
+interface RpcErrorShape {
+  message?: string;
+  data?: unknown;
+}
+
+interface RpcResponse<T> {
+  result?: T;
+  error?: RpcErrorShape;
+}
+
+interface RpcLog {
+  address: string;
+  topics: string[];
+  data: string;
+}
+
+interface RpcReceipt {
+  transactionHash: string;
+  contractAddress: string | null;
+  gasUsed: string;
+  status: string;
+  logs: RpcLog[];
+}
+
+interface RpcCallFrame {
+  type?: string;
+  from?: string;
+  to?: string;
+  input?: string;
+  output?: string;
+  error?: string;
+  revertReason?: string;
+  calls?: RpcCallFrame[];
+}
+
+interface RpcTraceResult {
+  gas?: number;
+  returnValue?: string;
+  failed?: boolean;
+  revertReason?: string;
+  structLogs?: Array<{ op?: string; depth?: number; stack?: string[]; memory?: string[] }>;
+}
+
+export interface DeployerService {
+  deployLocal: (input: mcp.deployer.DeployLocalInput) => Promise<{
+    address: `0x${string}`;
+    txHash: `0x${string}`;
+    gasUsed: string;
+  }>;
+  simulateLocal: (input: mcp.deployer.SimulateLocalInput) => Promise<{
+    result: `0x${string}`;
+    gasEstimate: string;
+    revertReason?: string;
+    logs: Array<{
+      address: `0x${string}`;
+      topics: Array<`0x${string}`>;
+      data: `0x${string}`;
+    }>;
+  }>;
+  trace: (input: mcp.deployer.TraceInput) => Promise<{
+    txHash: `0x${string}`;
+    decodedCalls: mcp.deployer.TraceOutput['decodedCalls'];
+    storageReads: mcp.deployer.TraceOutput['storageReads'];
+    storageWrites: mcp.deployer.TraceOutput['storageWrites'];
+    events: mcp.deployer.TraceOutput['events'];
+    revertReason?: string;
+    gasUsed: string;
+  }>;
+  call: (input: mcp.deployer.CallInput) => Promise<{ result: `0x${string}` }>;
+}
+
+/**
+ * Resolve symlinks on both paths and verify `candidatePath` is contained
+ * within `workspaceRoot`. Returns the workspace-relative path on success.
+ */
+export async function assertContainedInWorkspace(
+  workspaceRoot: string,
+  candidatePath: string,
+): Promise<string> {
+  const [resolvedRoot, resolvedCandidate] = await Promise.all([
+    realpath(workspaceRoot),
+    realpath(candidatePath).catch(() => candidatePath),
+  ]);
+  const rel = relative(resolvedRoot, resolvedCandidate);
+  if (rel.startsWith('..') || isAbsolute(rel)) {
+    throw new Error('path must resolve within the workspace root');
+  }
+  return rel;
+}
+
+async function rpc<T = unknown>(
+  rpcUrl: string,
+  method: string,
+  params: unknown[] = [],
+): Promise<T> {
+  const res = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(
+      `JSON-RPC request failed: HTTP ${res.status} ${res.statusText}${text ? ` — ${text}` : ''}`,
+    );
+  }
+
+  let data: RpcResponse<T>;
+  try {
+    data = (await res.json()) as RpcResponse<T>;
+  } catch (e) {
+    throw new Error(`JSON-RPC (${method}) parse error: ${String(e)}`, { cause: e });
+  }
+
+  if (data.error) {
+    const detail = extractRpcErrorDetail(data.error.data);
+    throw new Error(
+      `JSON-RPC error (${method}): ${data.error.message ?? 'Unknown error'}${detail ? ` — ${detail}` : ''}`,
+    );
+  }
+
+  return data.result as T;
+}
+
+async function rpcWithError<T = unknown>(
+  rpcUrl: string,
+  method: string,
+  params: unknown[] = [],
+): Promise<{ result?: T; error?: RpcErrorShape }> {
+  const res = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    return {
+      error: {
+        message: `HTTP ${res.status} ${res.statusText}${text ? ` — ${text}` : ''}`,
+      },
+    };
+  }
+
+  try {
+    return (await res.json()) as { result?: T; error?: RpcErrorShape };
+  } catch (e) {
+    return {
+      error: { message: `Parse error: ${String(e)}` },
+    };
+  }
+}
+
+function toHexQuantity(value: bigint): string {
+  return `0x${value.toString(16)}`;
+}
+
+function decodeRevertReasonFromData(data: string | undefined): string | undefined {
+  if (!data || !data.startsWith('0x')) return undefined;
+  const clean = data.slice(2);
+  if (!clean.startsWith('08c379a0')) return undefined;
+  if (clean.length < 8 + 64 + 64) return undefined;
+
+  try {
+    const lengthOffset = 8 + 64;
+    const strLenHex = clean.slice(lengthOffset, lengthOffset + 64);
+    const strLen = Number.parseInt(strLenHex, 16);
+    if (!Number.isFinite(strLen) || strLen < 0) return undefined;
+
+    const strStart = lengthOffset + 64;
+    const strEnd = strStart + strLen * 2;
+    const strHex = clean.slice(strStart, strEnd);
+    if (strHex.length !== strLen * 2) return undefined;
+
+    return Buffer.from(strHex, 'hex').toString('utf8');
+  } catch {
+    return undefined;
+  }
+}
+
+function extractRpcErrorData(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.startsWith('0x')) return value;
+  if (!value || typeof value !== 'object') return undefined;
+
+  const maybeData = (value as Record<string, unknown>)['data'];
+  if (typeof maybeData === 'string' && maybeData.startsWith('0x')) return maybeData;
+
+  const nested = (value as Record<string, unknown>)['originalError'];
+  if (nested && typeof nested === 'object') {
+    const nestedData = (nested as Record<string, unknown>)['data'];
+    if (typeof nestedData === 'string' && nestedData.startsWith('0x')) return nestedData;
+  }
+
+  return undefined;
+}
+
+function extractRpcErrorDetail(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (!value || typeof value !== 'object') return undefined;
+
+  const msg = (value as Record<string, unknown>)['message'];
+  if (typeof msg === 'string') return msg;
+
+  const reason = (value as Record<string, unknown>)['reason'];
+  if (typeof reason === 'string') return reason;
+
+  return undefined;
+}
+
+async function waitForReceipt(
+  chainRpcUrl: string,
+  txHash: string,
+  timeoutMs = 20_000,
+): Promise<RpcReceipt> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const receipt = await rpc<RpcReceipt | null>(chainRpcUrl, 'eth_getTransactionReceipt', [
+      txHash,
+    ]);
+    if (receipt) return receipt;
+    await Bun.sleep(200);
+  }
+  throw new Error(`Timed out waiting for receipt: ${txHash}`);
+}
+
+function callFramesToDecodedCalls(
+  root: RpcCallFrame | undefined,
+): mcp.deployer.TraceOutput['decodedCalls'] {
+  if (!root) return [];
+
+  const out: mcp.deployer.TraceOutput['decodedCalls'] = [];
+  const walk = (frame: RpcCallFrame, depth: number) => {
+    if (frame.to) {
+      out.push({
+        depth,
+        to: frame.to as `0x${string}`,
+        fn: frame.type ?? 'call',
+        args: [],
+        result: frame.output ?? null,
+        reverted: Boolean(frame.error ?? frame.revertReason),
+      });
+    }
+    for (const child of frame.calls ?? []) {
+      walk(child, depth + 1);
+    }
+  };
+
+  walk(root, 0);
+  return out;
+}
+
+export function createDeployerService(opts: {
+  chainRpcUrl: string;
+  workspaceRoot: string;
+}): DeployerService {
+  const { chainRpcUrl } = opts;
+
+  return {
+    async deployLocal(input) {
+      const sender =
+        input.sender ??
+        (await rpc<string[]>(chainRpcUrl, 'eth_accounts')).at(0) ??
+        (() => {
+          throw new Error('No local chain accounts available');
+        })();
+
+      const data = `${input.bytecode}${input.constructorData.slice(2)}`;
+      const txHash = await rpc<string>(chainRpcUrl, 'eth_sendTransaction', [
+        {
+          from: sender,
+          to: null,
+          data,
+          ...(input.value !== undefined ? { value: toHexQuantity(input.value) } : {}),
+        },
+      ]);
+
+      const receipt = await waitForReceipt(chainRpcUrl, txHash);
+      if (!receipt.contractAddress) {
+        throw new Error(`Deploy transaction did not produce a contract address: ${txHash}`);
+      }
+
+      return {
+        address: receipt.contractAddress as `0x${string}`,
+        txHash: txHash as `0x${string}`,
+        gasUsed: encodeBigInt(BigInt(receipt.gasUsed)),
+      };
+    },
+
+    async simulateLocal(input) {
+      const tx = {
+        ...(input.tx.from ? { from: input.tx.from } : {}),
+        ...(input.tx.to ? { to: input.tx.to } : { to: null }),
+        data: input.tx.data,
+        ...(input.tx.value !== undefined ? { value: toHexQuantity(input.tx.value) } : {}),
+        ...(input.tx.gas !== undefined ? { gas: toHexQuantity(input.tx.gas) } : {}),
+      };
+
+      const [callRes, estimateRes] = await Promise.all([
+        rpcWithError<string>(chainRpcUrl, 'eth_call', [tx, 'latest']),
+        rpcWithError<string>(chainRpcUrl, 'eth_estimateGas', [tx]),
+      ]);
+
+      const callErrorData = extractRpcErrorData(callRes.error?.data);
+      const revertReason =
+        decodeRevertReasonFromData(callErrorData) ?? extractRpcErrorDetail(callRes.error?.data);
+
+      const logs: mcp.deployer.SimulateLocalOutput['logs'] = [];
+
+      return {
+        result: (callRes.result ?? '0x') as `0x${string}`,
+        gasEstimate:
+          estimateRes.result !== undefined
+            ? encodeBigInt(BigInt(estimateRes.result))
+            : encodeBigInt(input.tx.gas ?? 0n),
+        ...(revertReason ? { revertReason } : {}),
+        logs,
+      };
+    },
+
+    async trace(input) {
+      const [traceRes, callTraceRes, receipt] = await Promise.all([
+        rpcWithError<RpcTraceResult>(chainRpcUrl, 'debug_traceTransaction', [input.txHash, {}]),
+        rpcWithError<RpcCallFrame>(chainRpcUrl, 'debug_traceTransaction', [
+          input.txHash,
+          { tracer: 'callTracer' },
+        ]),
+        rpc<RpcReceipt | null>(chainRpcUrl, 'eth_getTransactionReceipt', [input.txHash]),
+      ]);
+
+      if (!receipt) {
+        throw new Error(`Transaction receipt not found: ${input.txHash}`);
+      }
+
+      const revertData = extractRpcErrorData(traceRes.error?.data);
+      const revertReason =
+        decodeRevertReasonFromData(revertData) ??
+        traceRes.result?.revertReason ??
+        callTraceRes.result?.revertReason ??
+        extractRpcErrorDetail(traceRes.error?.data);
+
+      return {
+        txHash: receipt.transactionHash as `0x${string}`,
+        decodedCalls: callFramesToDecodedCalls(callTraceRes.result),
+        storageReads: [],
+        storageWrites: [],
+        events: [],
+        ...(revertReason ? { revertReason } : {}),
+        gasUsed: encodeBigInt(BigInt(receipt.gasUsed)),
+      };
+    },
+
+    async call(input) {
+      const result = await rpc<string>(chainRpcUrl, 'eth_call', [
+        {
+          to: input.to,
+          data: input.data,
+          ...(input.from ? { from: input.from } : {}),
+        },
+        'latest',
+      ]);
+      return { result: result as `0x${string}` };
+    },
+  };
+}

--- a/packages/mcp-deployer/src/service.ts
+++ b/packages/mcp-deployer/src/service.ts
@@ -81,10 +81,18 @@ export async function assertContainedInWorkspace(
   workspaceRoot: string,
   candidatePath: string,
 ): Promise<string> {
-  const [resolvedRoot, resolvedCandidate] = await Promise.all([
-    realpath(workspaceRoot),
-    realpath(candidatePath).catch(() => candidatePath),
-  ]);
+  const resolvedRoot = await realpath(workspaceRoot);
+  let resolvedCandidate: string;
+  try {
+    resolvedCandidate = await realpath(candidatePath);
+  } catch {
+    // File doesn't exist yet. Swap the raw workspaceRoot prefix for the
+    // resolved root so symlink differences (e.g. /tmp → /private/tmp on macOS)
+    // don't cause a false "outside workspace" rejection.
+    resolvedCandidate = candidatePath.startsWith(workspaceRoot)
+      ? resolvedRoot + candidatePath.slice(workspaceRoot.length)
+      : candidatePath;
+  }
   const rel = relative(resolvedRoot, resolvedCandidate);
   if (rel.startsWith('..') || isAbsolute(rel)) {
     throw new Error('path must resolve within the workspace root');

--- a/packages/mcp-deployer/test/service.test.ts
+++ b/packages/mcp-deployer/test/service.test.ts
@@ -40,7 +40,12 @@ describe('mcp-deployer service', () => {
   });
 
   it('deployLocal sends tx and returns address/hash/gas from receipt', async () => {
-    globalThis.fetch = (async (_url, init) => {
+    globalThis.fetch = (async (url, init) => {
+      // Compiler bytecode endpoint
+      if (typeof url === 'string' && url.includes('/bytecode/')) {
+        return jsonResponse({ bytecode: '0x60006000' });
+      }
+
       const body = JSON.parse(String(init?.body ?? '{}')) as {
         method?: string;
       };
@@ -71,10 +76,14 @@ describe('mcp-deployer service', () => {
       }
     }) as typeof fetch;
 
-    const service = createDeployerService({ chainRpcUrl: 'http://rpc.local', workspaceRoot });
+    const service = createDeployerService({
+      chainRpcUrl: 'http://rpc.local',
+      workspaceRoot,
+      compilerUrl: 'http://compiler.local',
+    });
 
     const output = await service.deployLocal({
-      bytecode: '0x60006000',
+      contractName: 'Counter',
       constructorData: '0x',
     });
 

--- a/packages/mcp-deployer/test/service.test.ts
+++ b/packages/mcp-deployer/test/service.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { assertContainedInWorkspace, createDeployerService } from '../src/service.ts';
+
+const ADDRESS_A = '0x1111111111111111111111111111111111111111';
+const ADDRESS_C = '0x2222222222222222222222222222222222222222';
+const TX_HASH = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('mcp-deployer service', () => {
+  let workspaceRoot = '';
+
+  beforeEach(async () => {
+    workspaceRoot = await mkdtemp(join(tmpdir(), 'crucible-mcp-deployer-test-'));
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it('assertContainedInWorkspace allows in-workspace paths and rejects outside paths', async () => {
+    await expect(
+      assertContainedInWorkspace(workspaceRoot, join(workspaceRoot, 'contracts', 'A.sol')),
+    ).resolves.toBe('contracts/A.sol');
+
+    await expect(assertContainedInWorkspace(workspaceRoot, '/etc/passwd')).rejects.toThrow(
+      'path must resolve within the workspace root',
+    );
+  });
+
+  it('deployLocal sends tx and returns address/hash/gas from receipt', async () => {
+    globalThis.fetch = (async (_url, init) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as {
+        method?: string;
+      };
+
+      switch (body.method) {
+        case 'eth_accounts':
+          return jsonResponse({ jsonrpc: '2.0', id: 1, result: [ADDRESS_A] });
+        case 'eth_sendTransaction':
+          return jsonResponse({ jsonrpc: '2.0', id: 1, result: TX_HASH });
+        case 'eth_getTransactionReceipt':
+          return jsonResponse({
+            jsonrpc: '2.0',
+            id: 1,
+            result: {
+              transactionHash: TX_HASH,
+              contractAddress: ADDRESS_C,
+              gasUsed: '0x5208',
+              status: '0x1',
+              logs: [],
+            },
+          });
+        default:
+          return jsonResponse({
+            jsonrpc: '2.0',
+            id: 1,
+            error: { message: `unexpected method: ${body.method}` },
+          });
+      }
+    }) as typeof fetch;
+
+    const service = createDeployerService({ chainRpcUrl: 'http://rpc.local', workspaceRoot });
+
+    const output = await service.deployLocal({
+      bytecode: '0x60006000',
+      constructorData: '0x',
+    });
+
+    expect(output.address).toBe(ADDRESS_C);
+    expect(output.txHash).toBe(TX_HASH);
+    expect(output.gasUsed).toBe('21000');
+  });
+
+  it('call forwards eth_call and returns raw hex result', async () => {
+    globalThis.fetch = (async (_url, init) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as {
+        method?: string;
+      };
+
+      if (body.method === 'eth_call') {
+        return jsonResponse({
+          jsonrpc: '2.0',
+          id: 1,
+          result: '0x00000000000000000000000000000001',
+        });
+      }
+
+      return jsonResponse({ jsonrpc: '2.0', id: 1, error: { message: 'unexpected method' } });
+    }) as typeof fetch;
+
+    const service = createDeployerService({ chainRpcUrl: 'http://rpc.local', workspaceRoot });
+    const output = await service.call({
+      to: ADDRESS_A,
+      data: '0x1234',
+    });
+
+    expect(output.result).toBe('0x00000000000000000000000000000001');
+  });
+});

--- a/packages/mcp-deployer/tsconfig.json
+++ b/packages/mcp-deployer/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/mcp-memory/.env.example
+++ b/packages/mcp-memory/.env.example
@@ -1,0 +1,12 @@
+# Port for memory MCP HTTP server
+MEMORY_MCP_PORT=3104
+
+# Workspace root for local JSON memory store
+WORKSPACE_ROOT=.
+
+# Optional metadata for created pattern provenance
+NODE_ID=local-node
+SESSION_ID=local-session
+
+# Optional comma-separated extra allowed Host headers
+# ALLOWED_HOSTS=macbook,100.x.y.z

--- a/packages/mcp-memory/package.json
+++ b/packages/mcp-memory/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@crucible/mcp-memory",
+  "version": "0.0.0",
+  "private": true,
+  "description": "MCP server — local memory pattern store with stable MCP interface.",
+  "license": "UNLICENSED",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "dev": "portless --name memory.crucible --app-port 3104 bun run --hot src/index.ts",
+    "start": "bun run src/index.ts",
+    "build": "echo 'Bun runtime — no compile step'",
+    "check-types": "tsc --noEmit",
+    "lint": "eslint .",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@cfworker/json-schema": "^4.1.1",
+    "@crucible/types": "workspace:*",
+    "@hono/zod-openapi": "^1.3.0",
+    "@modelcontextprotocol/hono": "2.0.0-alpha.2",
+    "@modelcontextprotocol/server": "2.0.0-alpha.2",
+    "hono": "^4.0.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.6",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/mcp-memory/src/index.ts
+++ b/packages/mcp-memory/src/index.ts
@@ -1,0 +1,229 @@
+/**
+ * mcp-memory entry point.
+ *
+ * Starts an OpenAPIHono HTTP server on DEFAULT_MCP_PORTS.memory (3104) or
+ * the port specified by MEMORY_MCP_PORT.
+ *
+ * Exposes both:
+ *   POST /mcp   — MCP protocol transport (hidden from OpenAPI docs)
+ *   REST routes — typed endpoints consumable via hc<AppType> from the frontend
+ *
+ * Environment flags:
+ *   MEMORY_MCP_PORT=N     — override the listen port
+ *   WORKSPACE_ROOT=<path> — workspace root for .crucible/memory storage (defaults to cwd)
+ */
+
+import { existsSync } from 'node:fs';
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
+import { hostHeaderValidation } from '@modelcontextprotocol/hono';
+import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
+import { z } from 'zod';
+import { mcp } from '@crucible/types';
+import {
+  RecallInputSchema,
+  RememberInputSchema,
+  ListPatternsInputSchema,
+  ProvenanceInputSchema,
+} from '@crucible/types/mcp/memory';
+import { createMemoryServer } from './server.ts';
+import { createMemoryService } from './service.ts';
+
+const PORT = process.env['MEMORY_MCP_PORT']
+  ? parseInt(process.env['MEMORY_MCP_PORT'], 10)
+  : mcp.DEFAULT_MCP_PORTS.memory;
+
+const WORKSPACE_ROOT = process.env['WORKSPACE_ROOT'] ?? process.cwd();
+
+console.log(`[mcp-memory] starting on port ${PORT} (workspaceRoot: ${WORKSPACE_ROOT})`);
+
+if (!existsSync(WORKSPACE_ROOT)) {
+  throw new Error(`[mcp-memory] WORKSPACE_ROOT does not exist: ${WORKSPACE_ROOT}`);
+}
+
+const service = createMemoryService({ workspaceRoot: WORKSPACE_ROOT });
+
+const ErrorSchema = z.object({ error: z.string() });
+
+// Wire-format schemas (no branded outputs) for OpenAPI route typing.
+const MemoryProvenanceWireSchema = z.object({
+  authorNode: z.string(),
+  originalSession: z.string(),
+  derivedFrom: z.array(z.string()).optional(),
+});
+
+const MemoryPatternWireSchema = z.object({
+  id: z.string(),
+  revertSignature: z.string(),
+  patch: z.string(),
+  traceRef: z.string(),
+  verificationReceipt: z.string(),
+  provenance: MemoryProvenanceWireSchema,
+  scope: z.enum(['local', 'mesh']),
+  createdAt: z.number().int().nonnegative(),
+});
+
+const RecallOutputWireSchema = z.object({
+  hits: z.array(
+    z.object({
+      pattern: MemoryPatternWireSchema,
+      score: z.number().min(0).max(1),
+    }),
+  ),
+});
+
+const RememberOutputWireSchema = z.object({ id: z.string() });
+
+const ListPatternsOutputWireSchema = z.object({
+  patterns: z.array(MemoryPatternWireSchema),
+  nextCursor: z.string().nullable(),
+});
+
+const recallRoute = createRoute({
+  method: 'post',
+  path: '/recall',
+  request: {
+    body: { content: { 'application/json': { schema: RecallInputSchema } }, required: true },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: RecallOutputWireSchema } },
+      description: 'Recall matches',
+    },
+    500: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Error' },
+  },
+});
+
+const rememberRoute = createRoute({
+  method: 'post',
+  path: '/remember',
+  request: {
+    body: { content: { 'application/json': { schema: RememberInputSchema } }, required: true },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: RememberOutputWireSchema } },
+      description: 'Stored pattern id',
+    },
+    500: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Error' },
+  },
+});
+
+const listPatternsRoute = createRoute({
+  method: 'get',
+  path: '/patterns',
+  request: { query: ListPatternsInputSchema },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: ListPatternsOutputWireSchema } },
+      description: 'Pattern page',
+    },
+    500: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Error' },
+  },
+});
+
+const provenanceRoute = createRoute({
+  method: 'get',
+  path: '/provenance/{id}',
+  request: { params: ProvenanceInputSchema },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: MemoryProvenanceWireSchema } },
+      description: 'Pattern provenance',
+    },
+    500: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Error' },
+  },
+});
+
+const mcpServer = createMemoryServer({ workspaceRoot: WORKSPACE_ROOT });
+
+type Env = { Variables: { parsedBody: unknown } };
+
+const transport = new WebStandardStreamableHTTPServerTransport();
+await mcpServer.connect(transport);
+
+const app = new OpenAPIHono<Env>();
+
+const extraHosts = process.env['ALLOWED_HOSTS']
+  ? process.env['ALLOWED_HOSTS']
+      .split(',')
+      .map((h) => h.trim())
+      .filter(Boolean)
+  : [];
+app.use('*', hostHeaderValidation(['localhost', '127.0.0.1', '::1', '[::1]', ...extraHosts]));
+
+app.use('*', async (c, next) => {
+  if (c.req.header('content-type')?.includes('application/json')) {
+    try {
+      c.set('parsedBody', await c.req.json<unknown>());
+    } catch {
+      // non-JSON or empty body
+    }
+  }
+  await next();
+});
+
+app.use('*', async (c, next) => {
+  const path = new URL(c.req.url).pathname;
+  if (path === '/doc') {
+    await next();
+    return;
+  }
+  const start = Date.now();
+  console.log(`[mcp-memory] → ${c.req.method} ${path}`);
+  await next();
+  const ms = Date.now() - start;
+  const status = c.res?.status ?? 0;
+  const logFn = status >= 500 ? console.error : status >= 400 ? console.warn : console.log;
+  logFn(`[mcp-memory] ← ${status} (${ms}ms)`);
+});
+
+app.openapi(recallRoute, async (c) => {
+  try {
+    const output = await service.recall(c.req.valid('json'));
+    return c.json(output, 200);
+  } catch (err) {
+    console.error(`[mcp-memory] recall error: ${String(err)}`);
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+app.openapi(rememberRoute, async (c) => {
+  try {
+    const output = await service.remember(c.req.valid('json'));
+    return c.json(output, 200);
+  } catch (err) {
+    console.error(`[mcp-memory] remember error: ${String(err)}`);
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+app.openapi(listPatternsRoute, async (c) => {
+  try {
+    const output = await service.listPatterns(c.req.valid('query'));
+    return c.json(output, 200);
+  } catch (err) {
+    console.error(`[mcp-memory] list_patterns error: ${String(err)}`);
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+app.openapi(provenanceRoute, async (c) => {
+  try {
+    const output = await service.provenance(c.req.valid('param'));
+    return c.json(output, 200);
+  } catch (err) {
+    console.error(`[mcp-memory] provenance error: ${String(err)}`);
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+app.all('/mcp', (c) => transport.handleRequest(c.req.raw, { parsedBody: c.get('parsedBody') }));
+
+app.doc('/doc', { openapi: '3.0.0', info: { version: '0.0.0', title: 'crucible-memory' } });
+
+export type AppType = typeof app;
+
+export default {
+  port: PORT,
+  fetch: app.fetch,
+};

--- a/packages/mcp-memory/src/server.ts
+++ b/packages/mcp-memory/src/server.ts
@@ -1,0 +1,139 @@
+import { McpServer, type CallToolResult } from '@modelcontextprotocol/server';
+import {
+  RecallInputSchema,
+  RememberInputSchema,
+  ListPatternsInputSchema,
+  ProvenanceInputSchema,
+  type RecallInput,
+  type RememberInput,
+  type ListPatternsInput,
+  type ProvenanceInput,
+} from '@crucible/types/mcp/memory';
+import { createMemoryService } from './service.ts';
+
+const TAG = '[mcp-memory]';
+const log = (msg: string) => console.log(`${TAG} ${msg}`);
+const logError = (msg: string) => console.error(`${TAG} ${msg}`);
+
+function toolResult(data: unknown): CallToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(data) }],
+    structuredContent: data as Record<string, unknown>,
+  };
+}
+
+function errorResult(message: string): CallToolResult {
+  return {
+    content: [{ type: 'text', text: message }],
+    isError: true,
+  };
+}
+
+export function createMemoryServer(opts: { workspaceRoot: string }): McpServer {
+  const service = createMemoryService(opts);
+  const server = new McpServer({
+    name: 'crucible-memory',
+    version: '0.0.0',
+  });
+
+  server.registerTool(
+    'recall',
+    {
+      title: 'Recall Similar Patterns',
+      description: 'Return top matching patterns for a revert signature or freeform query.',
+      inputSchema: RecallInputSchema,
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (input: RecallInput) => {
+      try {
+        log('tool:recall');
+        const output = await service.recall(input);
+        log(`tool:recall ok  hits=${output.hits.length}`);
+        return toolResult(output);
+      } catch (err) {
+        logError(`tool:recall error: ${String(err)}`);
+        return errorResult(`recall failed: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'remember',
+    {
+      title: 'Remember Verified Fix Pattern',
+      description: 'Append a verified revert->patch pattern into local memory storage.',
+      inputSchema: RememberInputSchema,
+      annotations: {
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (input: RememberInput) => {
+      try {
+        log('tool:remember');
+        const output = await service.remember(input);
+        log(`tool:remember ok  id=${output.id}`);
+        return toolResult(output);
+      } catch (err) {
+        logError(`tool:remember error: ${String(err)}`);
+        return errorResult(`remember failed: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'list_patterns',
+    {
+      title: 'List Stored Patterns',
+      description: 'List patterns with cursor-based pagination and optional scope filter.',
+      inputSchema: ListPatternsInputSchema,
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (input: ListPatternsInput) => {
+      try {
+        log('tool:list_patterns');
+        const output = await service.listPatterns(input);
+        log(`tool:list_patterns ok  count=${output.patterns.length}`);
+        return toolResult(output);
+      } catch (err) {
+        logError(`tool:list_patterns error: ${String(err)}`);
+        return errorResult(`list_patterns failed: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'provenance',
+    {
+      title: 'Get Pattern Provenance',
+      description: 'Return provenance information for a stored memory pattern by id.',
+      inputSchema: ProvenanceInputSchema,
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (input: ProvenanceInput) => {
+      try {
+        log(`tool:provenance id=${input.id}`);
+        const output = await service.provenance(input);
+        return toolResult(output);
+      } catch (err) {
+        logError(`tool:provenance error: ${String(err)}`);
+        return errorResult(`provenance failed: ${String(err)}`);
+      }
+    },
+  );
+
+  return server;
+}

--- a/packages/mcp-memory/src/server.ts
+++ b/packages/mcp-memory/src/server.ts
@@ -135,5 +135,82 @@ export function createMemoryServer(opts: { workspaceRoot: string }): McpServer {
     },
   );
 
+  // ── prompts ────────────────────────────────────────────────────────────────
+
+  server.registerPrompt(
+    'memory_workflow',
+    {
+      title: 'Memory Workflow',
+      description:
+        'Guide for storing and retrieving verified revert-fix patterns using crucible-memory.',
+    },
+    () => ({
+      messages: [
+        {
+          role: 'user' as const,
+          content: {
+            type: 'text' as const,
+            text: [
+              'You are connected to the crucible-memory MCP server.',
+              'It stores and retrieves verified revert→fix patterns to accelerate debugging.',
+              '',
+              'Typical workflow:',
+              '1. Call recall(query) with a revert signature or freeform description.',
+              '   - Returns top matching patterns ranked by similarity.',
+              '   - Each hit includes revertSignature, fix, contractName, and provenance.',
+              '2. Apply the suggested fix from the top hit to your contract or transaction.',
+              '3. Verify the fix resolves the issue (re-simulate in crucible-deployer).',
+              '4. Call remember(pattern) to persist the confirmed fix for future use.',
+              '   - Required fields: revertSignature, fix, contractName.',
+              '   - Optional: scope (file path), tags, notes.',
+              '5. Call list_patterns for paginated browsing of all stored patterns.',
+              '6. Call provenance(id) to see the source and timestamps for a specific pattern.',
+              '',
+              'Tool reference:',
+              '  recall         — Semantic search over stored patterns.',
+              '  remember       — Persist a verified revert→fix pattern.',
+              '  list_patterns  — Paginated list of all patterns.',
+              '  provenance     — Full metadata for a pattern by id.',
+            ].join('\n'),
+          },
+        },
+      ],
+    }),
+  );
+
+  server.registerPrompt(
+    'debug_and_learn',
+    {
+      title: 'Debug & Learn Loop',
+      description:
+        'Guide for using crucible-memory together with crucible-deployer to diagnose reverts and build up a fix-pattern library.',
+    },
+    () => ({
+      messages: [
+        {
+          role: 'user' as const,
+          content: {
+            type: 'text' as const,
+            text: [
+              'Debug-and-learn loop using crucible-deployer and crucible-memory:',
+              '',
+              '1. [deployer]  simulate_local or trace → extract the revert signature.',
+              '2. [memory]    recall(revertSignature) → check if a fix pattern already exists.',
+              '   a) Hit found   → apply the suggested fix, skip to step 5.',
+              '   b) No hit      → investigate manually (steps 3–4).',
+              '3. Diagnose the root cause from the trace (call stack, storage, events).',
+              '4. Apply a fix to the contract or transaction inputs.',
+              '5. [deployer]  simulate_local again → confirm the revert is resolved.',
+              '6. [memory]    remember({ revertSignature, fix, contractName, ... })',
+              '   - Captures the revert→fix mapping so future agents can skip steps 3–4.',
+              '',
+              'Over time this builds a project-specific fix library that reduces debugging time.',
+            ].join('\n'),
+          },
+        },
+      ],
+    }),
+  );
+
   return server;
 }

--- a/packages/mcp-memory/src/service.ts
+++ b/packages/mcp-memory/src/service.ts
@@ -1,0 +1,181 @@
+import { join } from 'node:path';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { type mcp } from '@crucible/types';
+
+interface StoredPattern {
+  id: string;
+  revertSignature: string;
+  patch: string;
+  traceRef: string;
+  verificationReceipt: `0x${string}`;
+  provenance: {
+    authorNode: string;
+    originalSession: string;
+    derivedFrom?: string[];
+  };
+  scope: 'local' | 'mesh';
+  createdAt: number;
+}
+
+export interface MemoryService {
+  recall: (
+    input: mcp.memory.RecallInput,
+  ) => Promise<{ hits: Array<{ pattern: StoredPattern; score: number }> }>;
+  remember: (input: mcp.memory.RememberInput) => Promise<{ id: string }>;
+  listPatterns: (
+    input: mcp.memory.ListPatternsInput,
+  ) => Promise<{ patterns: StoredPattern[]; nextCursor: string | null }>;
+  provenance: (input: mcp.memory.ProvenanceInput) => Promise<StoredPattern['provenance']>;
+}
+
+function normalize(text: string): string {
+  return text.trim().toLowerCase();
+}
+
+function safeParseCursor(cursor: string | undefined): number {
+  if (!cursor) return 0;
+  const parsed = Number.parseInt(cursor, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error('cursor must be a non-negative integer string');
+  }
+  return parsed;
+}
+
+function similarityByContainment(needle: string, haystack: string): number {
+  if (!needle) return 0;
+  if (haystack === needle) return 1;
+  if (haystack.includes(needle)) {
+    const ratio = needle.length / Math.max(needle.length, haystack.length);
+    return Math.max(0.7, ratio);
+  }
+  if (needle.includes(haystack) && haystack.length > 0) {
+    const ratio = haystack.length / needle.length;
+    return Math.max(0.5, ratio * 0.8);
+  }
+  return 0;
+}
+
+function scorePattern(pattern: StoredPattern, input: mcp.memory.RecallInput): number {
+  const fields = [pattern.revertSignature, pattern.patch, pattern.traceRef].map(normalize);
+
+  let score = 0;
+
+  const queryRevert = normalize(input.revertSignature ?? '');
+  if (queryRevert) {
+    score = Math.max(
+      score,
+      similarityByContainment(queryRevert, normalize(pattern.revertSignature)),
+    );
+  }
+
+  const queryContract = normalize(input.contractPattern ?? '');
+  if (queryContract) {
+    score = Math.max(
+      score,
+      ...fields.map((field) => similarityByContainment(queryContract, field) * 0.9),
+    );
+  }
+
+  const queryFreeform = normalize(input.freeform ?? '');
+  if (queryFreeform) {
+    score = Math.max(
+      score,
+      ...fields.map((field) => similarityByContainment(queryFreeform, field) * 0.8),
+    );
+  }
+
+  return Number(score.toFixed(4));
+}
+
+async function readPatterns(filePath: string): Promise<StoredPattern[]> {
+  try {
+    const raw = await readFile(filePath, 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed as StoredPattern[];
+    }
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      Array.isArray((parsed as { patterns?: unknown }).patterns)
+    ) {
+      return (parsed as { patterns: StoredPattern[] }).patterns;
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+async function writePatterns(filePath: string, patterns: StoredPattern[]): Promise<void> {
+  await mkdir(join(filePath, '..'), { recursive: true });
+  await writeFile(filePath, JSON.stringify(patterns, null, 2) + '\n', 'utf8');
+}
+
+export function createMemoryService(opts: { workspaceRoot: string }): MemoryService {
+  const patternsPath = join(opts.workspaceRoot, '.crucible', 'memory', 'patterns.json');
+  const authorNode = process.env['NODE_ID'] ?? 'local-node';
+  const originalSession = process.env['SESSION_ID'] ?? 'local-session';
+
+  return {
+    async recall(input) {
+      const patterns = await readPatterns(patternsPath);
+      const ranked = patterns
+        .map((pattern) => ({ pattern, score: scorePattern(pattern, input) }))
+        .filter((entry) => entry.score > 0)
+        .sort((a, b) => b.score - a.score || b.pattern.createdAt - a.pattern.createdAt);
+
+      const limit = input.limit ?? 5;
+      return {
+        hits: ranked.slice(0, limit),
+      };
+    },
+
+    async remember(input) {
+      const patterns = await readPatterns(patternsPath);
+      const id = `pattern-${Date.now()}-${randomUUID().slice(0, 8)}`;
+      const entry: StoredPattern = {
+        id,
+        revertSignature: input.revertSignature,
+        patch: input.patch,
+        traceRef: input.traceRef,
+        verificationReceipt: input.verificationReceipt,
+        provenance: {
+          authorNode,
+          originalSession,
+        },
+        scope: input.scope,
+        createdAt: Date.now(),
+      };
+      patterns.push(entry);
+      await writePatterns(patternsPath, patterns);
+      return { id };
+    },
+
+    async listPatterns(input) {
+      const patterns = await readPatterns(patternsPath);
+      const filtered = input.scope
+        ? patterns.filter((pattern) => pattern.scope === input.scope)
+        : patterns;
+      const offset = safeParseCursor(input.cursor);
+      const limit = input.limit ?? 50;
+      const page = filtered.slice(offset, offset + limit);
+      const next = offset + page.length;
+
+      return {
+        patterns: page,
+        nextCursor: next < filtered.length ? String(next) : null,
+      };
+    },
+
+    async provenance(input) {
+      const patterns = await readPatterns(patternsPath);
+      const found = patterns.find((pattern) => pattern.id === input.id);
+      if (!found) {
+        throw new Error(`Pattern not found: ${input.id}`);
+      }
+      return found.provenance;
+    },
+  };
+}

--- a/packages/mcp-memory/test/service.test.ts
+++ b/packages/mcp-memory/test/service.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { mcp } from '@crucible/types';
+import { createMemoryService } from '../src/service.ts';
+
+describe('mcp-memory service', () => {
+  let workspaceRoot = '';
+
+  beforeEach(async () => {
+    workspaceRoot = await mkdtemp(join(tmpdir(), 'crucible-mcp-memory-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it('remember appends pattern and provenance returns the same provenance', async () => {
+    const service = createMemoryService({ workspaceRoot });
+
+    const remembered = await service.remember({
+      revertSignature: 'ERC20: insufficient allowance',
+      patch: 'diff --git a/contracts/Token.sol b/contracts/Token.sol',
+      traceRef: 'trace://abc123',
+      verificationReceipt: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      scope: 'local',
+    });
+
+    expect(remembered.id.startsWith('pattern-')).toBe(true);
+
+    const provenanceInput = mcp.memory.ProvenanceInputSchema.parse({ id: remembered.id });
+    const provenance = await service.provenance(provenanceInput);
+    expect(provenance.authorNode).toBeTruthy();
+    expect(provenance.originalSession).toBeTruthy();
+  });
+
+  it('recall returns ranked hits for matching queries', async () => {
+    const service = createMemoryService({ workspaceRoot });
+
+    await service.remember({
+      revertSignature: 'Vault: cooldown active',
+      patch: 'update withdraw guard',
+      traceRef: 'trace://cooldown',
+      verificationReceipt: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      scope: 'local',
+    });
+
+    await service.remember({
+      revertSignature: 'AccessControl: missing role',
+      patch: 'add admin role assignment',
+      traceRef: 'trace://role',
+      verificationReceipt: '0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+      scope: 'mesh',
+    });
+
+    const out = await service.recall({
+      revertSignature: 'cooldown',
+      limit: 3,
+    });
+
+    expect(out.hits.length).toBeGreaterThan(0);
+    expect(out.hits[0]?.pattern.revertSignature).toContain('cooldown');
+    expect(out.hits[0]?.score).toBeGreaterThan(0);
+  });
+
+  it('listPatterns paginates with cursor as offset', async () => {
+    const service = createMemoryService({ workspaceRoot });
+
+    await service.remember({
+      revertSignature: 'Error A',
+      patch: 'patch A',
+      traceRef: 'trace://a',
+      verificationReceipt: '0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+      scope: 'local',
+    });
+    await service.remember({
+      revertSignature: 'Error B',
+      patch: 'patch B',
+      traceRef: 'trace://b',
+      verificationReceipt: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      scope: 'local',
+    });
+
+    const first = await service.listPatterns({ limit: 1 });
+    expect(first.patterns).toHaveLength(1);
+    expect(first.nextCursor).toBe('1');
+
+    const second = await service.listPatterns({ limit: 1, cursor: first.nextCursor ?? undefined });
+    expect(second.patterns).toHaveLength(1);
+  });
+});

--- a/packages/mcp-memory/tsconfig.json
+++ b/packages/mcp-memory/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/mcp-wallet/.env.example
+++ b/packages/mcp-wallet/.env.example
@@ -1,0 +1,11 @@
+# Port for wallet MCP HTTP server
+WALLET_MCP_PORT=3103
+
+# Internal chain RPC endpoint (mcp-chain)
+CHAIN_RPC_URL=http://localhost:3100
+
+# Workspace root for .crucible/state.json persistence
+WORKSPACE_ROOT=.
+
+# Optional comma-separated extra allowed Host headers
+# ALLOWED_HOSTS=macbook,100.x.y.z

--- a/packages/mcp-wallet/package.json
+++ b/packages/mcp-wallet/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@crucible/mcp-wallet",
+  "version": "0.0.0",
+  "private": true,
+  "description": "MCP server — embedded dev wallet account, signing, and local send tools.",
+  "license": "UNLICENSED",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "dev": "portless --name wallet.crucible --app-port 3103 bun run --hot src/index.ts",
+    "start": "bun run src/index.ts",
+    "build": "echo 'Bun runtime — no compile step'",
+    "check-types": "tsc --noEmit",
+    "lint": "eslint .",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@cfworker/json-schema": "^4.1.1",
+    "@crucible/types": "workspace:*",
+    "@hono/zod-openapi": "^1.3.0",
+    "@modelcontextprotocol/hono": "2.0.0-alpha.2",
+    "@modelcontextprotocol/server": "2.0.0-alpha.2",
+    "hono": "^4.0.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.6",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/mcp-wallet/src/index.ts
+++ b/packages/mcp-wallet/src/index.ts
@@ -34,7 +34,7 @@ const PORT = process.env['WALLET_MCP_PORT']
   ? parseInt(process.env['WALLET_MCP_PORT'], 10)
   : mcp.DEFAULT_MCP_PORTS.wallet;
 
-const CHAIN_RPC_URL = process.env['CHAIN_RPC_URL'] ?? 'http://localhost:3100';
+const CHAIN_RPC_URL = process.env['CHAIN_RPC_URL'] ?? 'http://localhost:3100/rpc';
 const WORKSPACE_ROOT = process.env['WORKSPACE_ROOT'] ?? process.cwd();
 
 console.log(

--- a/packages/mcp-wallet/src/index.ts
+++ b/packages/mcp-wallet/src/index.ts
@@ -1,0 +1,245 @@
+/**
+ * mcp-wallet entry point.
+ *
+ * Starts an OpenAPIHono HTTP server on DEFAULT_MCP_PORTS.wallet (3103) or
+ * the port specified by WALLET_MCP_PORT.
+ *
+ * Exposes both:
+ *   POST /mcp   — MCP protocol transport (hidden from OpenAPI docs)
+ *   REST routes — typed endpoints consumable via hc<AppType> from the frontend
+ *
+ * Environment flags:
+ *   WALLET_MCP_PORT=N     — override the listen port
+ *   CHAIN_RPC_URL=<url>   — chain RPC endpoint (defaults to http://localhost:3100)
+ *   WORKSPACE_ROOT=<path> — workspace root for .crucible/state.json (defaults to cwd)
+ */
+
+import { existsSync } from 'node:fs';
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
+import { hostHeaderValidation } from '@modelcontextprotocol/hono';
+import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
+import { z } from 'zod';
+import { mcp } from '@crucible/types';
+import {
+  ListAccountsInputSchema,
+  GetBalanceInputSchema,
+  SignTxInputSchema,
+  SendTxLocalInputSchema,
+  SwitchAccountInputSchema,
+} from '@crucible/types/mcp/wallet';
+import { createWalletServer } from './server.ts';
+import { createWalletService } from './service.ts';
+
+const PORT = process.env['WALLET_MCP_PORT']
+  ? parseInt(process.env['WALLET_MCP_PORT'], 10)
+  : mcp.DEFAULT_MCP_PORTS.wallet;
+
+const CHAIN_RPC_URL = process.env['CHAIN_RPC_URL'] ?? 'http://localhost:3100';
+const WORKSPACE_ROOT = process.env['WORKSPACE_ROOT'] ?? process.cwd();
+
+console.log(
+  `[mcp-wallet] starting on port ${PORT} (workspaceRoot: ${WORKSPACE_ROOT}, chainRpcUrl: ${CHAIN_RPC_URL})`,
+);
+
+if (!existsSync(WORKSPACE_ROOT)) {
+  throw new Error(`[mcp-wallet] WORKSPACE_ROOT does not exist: ${WORKSPACE_ROOT}`);
+}
+
+const service = createWalletService({ chainRpcUrl: CHAIN_RPC_URL, workspaceRoot: WORKSPACE_ROOT });
+
+const ErrorSchema = z.object({ error: z.string() });
+
+// Wire-format schemas (no branded/transformed outputs) for OpenAPI route typing.
+const ListAccountsOutputWireSchema = z.object({
+  accounts: z.array(
+    z.object({
+      label: z.string(),
+      address: z.string(),
+      balance: z.string(),
+    }),
+  ),
+});
+
+const GetBalanceOutputWireSchema = z.object({ balance: z.string() });
+const SignTxOutputWireSchema = z.object({ signedTx: z.string() });
+const SendTxLocalOutputWireSchema = z.object({
+  txHash: z.string(),
+  gasUsed: z.string(),
+  status: z.enum(['success', 'reverted']),
+});
+const SwitchAccountOutputWireSchema = z.object({ active: z.string() });
+
+const listAccountsRoute = createRoute({
+  method: 'get',
+  path: '/accounts',
+  request: { query: ListAccountsInputSchema },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: ListAccountsOutputWireSchema } },
+      description: 'Wallet accounts',
+    },
+    500: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Error' },
+  },
+});
+
+const getBalanceRoute = createRoute({
+  method: 'get',
+  path: '/balance/{address}',
+  request: { params: GetBalanceInputSchema },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: GetBalanceOutputWireSchema } },
+      description: 'Current balance',
+    },
+    500: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Error' },
+  },
+});
+
+const signTxRoute = createRoute({
+  method: 'post',
+  path: '/sign_tx',
+  request: {
+    body: { content: { 'application/json': { schema: SignTxInputSchema } }, required: true },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: SignTxOutputWireSchema } },
+      description: 'Signed transaction',
+    },
+    500: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Error' },
+  },
+});
+
+const sendTxLocalRoute = createRoute({
+  method: 'post',
+  path: '/send_tx_local',
+  request: {
+    body: { content: { 'application/json': { schema: SendTxLocalInputSchema } }, required: true },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: SendTxLocalOutputWireSchema } },
+      description: 'Local send result',
+    },
+    500: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Error' },
+  },
+});
+
+const switchAccountRoute = createRoute({
+  method: 'post',
+  path: '/switch_account',
+  request: {
+    body: { content: { 'application/json': { schema: SwitchAccountInputSchema } }, required: true },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: SwitchAccountOutputWireSchema } },
+      description: 'Active account switched',
+    },
+    500: { content: { 'application/json': { schema: ErrorSchema } }, description: 'Error' },
+  },
+});
+
+const mcpServer = createWalletServer({ chainRpcUrl: CHAIN_RPC_URL, workspaceRoot: WORKSPACE_ROOT });
+
+type Env = { Variables: { parsedBody: unknown } };
+
+const transport = new WebStandardStreamableHTTPServerTransport();
+await mcpServer.connect(transport);
+
+const app = new OpenAPIHono<Env>();
+
+const extraHosts = process.env['ALLOWED_HOSTS']
+  ? process.env['ALLOWED_HOSTS']
+      .split(',')
+      .map((h) => h.trim())
+      .filter(Boolean)
+  : [];
+app.use('*', hostHeaderValidation(['localhost', '127.0.0.1', '::1', '[::1]', ...extraHosts]));
+
+app.use('*', async (c, next) => {
+  if (c.req.header('content-type')?.includes('application/json')) {
+    try {
+      c.set('parsedBody', await c.req.json<unknown>());
+    } catch {
+      // non-JSON or empty body
+    }
+  }
+  await next();
+});
+
+app.use('*', async (c, next) => {
+  const path = new URL(c.req.url).pathname;
+  if (path === '/doc') {
+    await next();
+    return;
+  }
+  const start = Date.now();
+  console.log(`[mcp-wallet] → ${c.req.method} ${path}`);
+  await next();
+  const ms = Date.now() - start;
+  const status = c.res?.status ?? 0;
+  const logFn = status >= 500 ? console.error : status >= 400 ? console.warn : console.log;
+  logFn(`[mcp-wallet] ← ${status} (${ms}ms)`);
+});
+
+app.openapi(listAccountsRoute, async (c) => {
+  try {
+    const output = await service.listAccounts();
+    return c.json(output, 200);
+  } catch (err) {
+    console.error(`[mcp-wallet] list_accounts error: ${String(err)}`);
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+app.openapi(getBalanceRoute, async (c) => {
+  try {
+    const output = await service.getBalance(c.req.valid('param'));
+    return c.json(output, 200);
+  } catch (err) {
+    console.error(`[mcp-wallet] get_balance error: ${String(err)}`);
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+app.openapi(signTxRoute, async (c) => {
+  try {
+    const output = await service.signTx(c.req.valid('json'));
+    return c.json(output, 200);
+  } catch (err) {
+    console.error(`[mcp-wallet] sign_tx error: ${String(err)}`);
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+app.openapi(sendTxLocalRoute, async (c) => {
+  try {
+    const output = await service.sendTxLocal(c.req.valid('json'));
+    return c.json(output, 200);
+  } catch (err) {
+    console.error(`[mcp-wallet] send_tx_local error: ${String(err)}`);
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+app.openapi(switchAccountRoute, async (c) => {
+  try {
+    const output = await service.switchAccount(c.req.valid('json'));
+    return c.json(output, 200);
+  } catch (err) {
+    console.error(`[mcp-wallet] switch_account error: ${String(err)}`);
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+app.all('/mcp', (c) => transport.handleRequest(c.req.raw, { parsedBody: c.get('parsedBody') }));
+
+app.doc('/doc', { openapi: '3.0.0', info: { version: '0.0.0', title: 'crucible-wallet' } });
+
+export type AppType = typeof app;
+
+export default {
+  port: PORT,
+  fetch: app.fetch,
+};

--- a/packages/mcp-wallet/src/server.ts
+++ b/packages/mcp-wallet/src/server.ts
@@ -1,0 +1,166 @@
+import { McpServer, type CallToolResult } from '@modelcontextprotocol/server';
+import {
+  ListAccountsInputSchema,
+  GetBalanceInputSchema,
+  SignTxInputSchema,
+  SendTxLocalInputSchema,
+  SwitchAccountInputSchema,
+  type GetBalanceInput,
+  type SignTxInput,
+  type SendTxLocalInput,
+  type SwitchAccountInput,
+} from '@crucible/types/mcp/wallet';
+import { createWalletService } from './service.ts';
+
+const TAG = '[mcp-wallet]';
+const log = (msg: string) => console.log(`${TAG} ${msg}`);
+const logError = (msg: string) => console.error(`${TAG} ${msg}`);
+
+function toolResult(data: unknown): CallToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(data) }],
+    structuredContent: data as Record<string, unknown>,
+  };
+}
+
+function errorResult(message: string): CallToolResult {
+  return {
+    content: [{ type: 'text', text: message }],
+    isError: true,
+  };
+}
+
+export function createWalletServer(opts: {
+  chainRpcUrl: string;
+  workspaceRoot: string;
+}): McpServer {
+  const service = createWalletService(opts);
+  const server = new McpServer({
+    name: 'crucible-wallet',
+    version: '0.0.0',
+  });
+
+  server.registerTool(
+    'list_accounts',
+    {
+      title: 'List Dev Wallet Accounts',
+      description: 'Return local chain accounts with stable labels and current balances.',
+      inputSchema: ListAccountsInputSchema,
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async () => {
+      try {
+        log('tool:list_accounts');
+        const output = await service.listAccounts();
+        log(`tool:list_accounts ok  count=${output.accounts.length}`);
+        return toolResult(output);
+      } catch (err) {
+        logError(`tool:list_accounts error: ${String(err)}`);
+        return errorResult(`list_accounts failed: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'get_balance',
+    {
+      title: 'Get Account Balance',
+      description: 'Return current wei balance for a local-chain account address.',
+      inputSchema: GetBalanceInputSchema,
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (input: GetBalanceInput) => {
+      try {
+        log(`tool:get_balance address=${input.address}`);
+        const output = await service.getBalance(input);
+        return toolResult(output);
+      } catch (err) {
+        logError(`tool:get_balance error: ${String(err)}`);
+        return errorResult(`get_balance failed: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'sign_tx',
+    {
+      title: 'Sign Transaction',
+      description: 'Sign a local transaction with an unlocked Hardhat test account.',
+      inputSchema: SignTxInputSchema,
+      annotations: {
+        readOnlyHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (input: SignTxInput) => {
+      try {
+        log(`tool:sign_tx from=${input.tx.from}`);
+        const output = await service.signTx(input);
+        return toolResult(output);
+      } catch (err) {
+        logError(`tool:sign_tx error: ${String(err)}`);
+        return errorResult(`sign_tx failed: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'send_tx_local',
+    {
+      title: 'Send Signed Local Transaction',
+      description: 'Sign and broadcast a local-chain transaction via eth_sendRawTransaction.',
+      inputSchema: SendTxLocalInputSchema,
+      annotations: {
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (input: SendTxLocalInput) => {
+      try {
+        log(`tool:send_tx_local from=${input.tx.from}`);
+        const output = await service.sendTxLocal(input);
+        log(`tool:send_tx_local ok  txHash=${output.txHash}`);
+        return toolResult(output);
+      } catch (err) {
+        logError(`tool:send_tx_local error: ${String(err)}`);
+        return errorResult(`send_tx_local failed: ${String(err)}`);
+      }
+    },
+  );
+
+  server.registerTool(
+    'switch_account',
+    {
+      title: 'Switch Active Account',
+      description: 'Set active wallet account label and persist it in .crucible/state.json.',
+      inputSchema: SwitchAccountInputSchema,
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (input: SwitchAccountInput) => {
+      try {
+        log(`tool:switch_account label=${input.label}`);
+        const output = await service.switchAccount(input);
+        return toolResult(output);
+      } catch (err) {
+        logError(`tool:switch_account error: ${String(err)}`);
+        return errorResult(`switch_account failed: ${String(err)}`);
+      }
+    },
+  );
+
+  return server;
+}

--- a/packages/mcp-wallet/src/server.ts
+++ b/packages/mcp-wallet/src/server.ts
@@ -162,5 +162,88 @@ export function createWalletServer(opts: {
     },
   );
 
+  // ── prompts ────────────────────────────────────────────────────────────────
+
+  server.registerPrompt(
+    'wallet_workflow',
+    {
+      title: 'Dev Wallet Workflow',
+      description:
+        'Guide for managing local Hardhat test accounts, checking balances, and sending transactions.',
+    },
+    () => ({
+      messages: [
+        {
+          role: 'user' as const,
+          content: {
+            type: 'text' as const,
+            text: [
+              'You are connected to the crucible-wallet MCP server.',
+              'It manages the unlocked Hardhat test accounts on the local chain.',
+              '',
+              'Typical workflow:',
+              '1. Call list_accounts to see all available accounts with labels and balances.',
+              '   - Labels are stable (e.g. "deployer", "user1") and set in .crucible/state.json.',
+              '2. Call get_balance(address) for the current wei balance of a specific address.',
+              '3. Call switch_account(label) to set the active account for subsequent operations.',
+              '   - Persisted in .crucible/state.json.',
+              '4. Call send_tx_local(tx) to sign and broadcast a transaction on the local chain.',
+              '   - from, to, data, value, gas are the key fields.',
+              '   - Returns txHash; confirm with eth_getTransactionReceipt via the chain RPC.',
+              '5. Call sign_tx(tx) if you only need the signed payload without broadcasting.',
+              '',
+              'Tool reference:',
+              '  list_accounts  — Read-only: all accounts with labels and balances.',
+              '  get_balance    — Read-only: wei balance for one address.',
+              '  switch_account — Set active account label (persisted).',
+              '  send_tx_local  — Sign + broadcast a local-chain transaction.',
+              '  sign_tx        — Sign a transaction without broadcasting.',
+              '',
+              'Notes:',
+              '  - All accounts are Hardhat default accounts (unlocked, pre-funded with 10000 ETH).',
+              '  - Balances change when you deploy contracts or send transactions.',
+            ].join('\n'),
+          },
+        },
+      ],
+    }),
+  );
+
+  server.registerPrompt(
+    'send_transaction',
+    {
+      title: 'Sign & Send a Local Transaction',
+      description:
+        'Step-by-step guide for constructing and broadcasting a transaction on the local Hardhat chain.',
+    },
+    () => ({
+      messages: [
+        {
+          role: 'user' as const,
+          content: {
+            type: 'text' as const,
+            text: [
+              'Sending a transaction on the local chain:',
+              '',
+              '1. list_accounts → pick a funded account (note its address).',
+              '2. Optionally switch_account(label) to make it the active sender.',
+              '3. Build the transaction object:',
+              '     { from, to, data, value?, gas? }',
+              '   - data is ABI-encoded calldata (use contract ABI from crucible-compiler).',
+              '   - value is optional ETH to send (in wei).',
+              '   - gas defaults to eth_estimateGas if omitted.',
+              '4. Call send_tx_local(tx) → returns { txHash, receipt }.',
+              '5. Check receipt.status: "0x1" = success, "0x0" = revert.',
+              '   - On revert, use crucible-deployer simulate_local or trace to diagnose.',
+              '',
+              'If you only need the signed bytes (e.g. to relay later):',
+              '  - Call sign_tx(tx) instead — returns { signedTx } without broadcasting.',
+            ].join('\n'),
+          },
+        },
+      ],
+    }),
+  );
+
   return server;
 }

--- a/packages/mcp-wallet/src/service.ts
+++ b/packages/mcp-wallet/src/service.ts
@@ -1,0 +1,206 @@
+import { join } from 'node:path';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { encodeBigInt, type mcp } from '@crucible/types';
+
+const DEFAULT_LABELS = [
+  'Account 1',
+  'Account 2',
+  'Account 3',
+  'Account 4',
+  'Account 5',
+  'Account 6',
+  'Account 7',
+  'Account 8',
+  'Account 9',
+  'Account 10',
+] as const;
+
+interface RpcErrorShape {
+  message?: string;
+  data?: unknown;
+}
+
+interface RpcResponse<T> {
+  result?: T;
+  error?: RpcErrorShape;
+}
+
+interface StateShape {
+  wallet?: {
+    activeAccountLabel?: string;
+  };
+  [key: string]: unknown;
+}
+
+export interface WalletService {
+  listAccounts: () => Promise<{
+    accounts: Array<{ label: string; address: `0x${string}`; balance: string }>;
+  }>;
+  getBalance: (input: mcp.wallet.GetBalanceInput) => Promise<{ balance: string }>;
+  signTx: (input: mcp.wallet.SignTxInput) => Promise<{ signedTx: `0x${string}` }>;
+  sendTxLocal: (input: mcp.wallet.SendTxLocalInput) => Promise<{
+    txHash: `0x${string}`;
+    gasUsed: string;
+    status: 'success' | 'reverted';
+  }>;
+  switchAccount: (input: mcp.wallet.SwitchAccountInput) => Promise<{ active: `0x${string}` }>;
+}
+
+interface RpcReceipt {
+  gasUsed: string;
+  status: string;
+}
+
+async function rpc<T = unknown>(
+  rpcUrl: string,
+  method: string,
+  params: unknown[] = [],
+): Promise<T> {
+  const res = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(
+      `JSON-RPC request failed: HTTP ${res.status} ${res.statusText}${text ? ` — ${text}` : ''}`,
+    );
+  }
+
+  let data: RpcResponse<T>;
+  try {
+    data = (await res.json()) as RpcResponse<T>;
+  } catch (e) {
+    throw new Error(`JSON-RPC (${method}) parse error: ${String(e)}`, { cause: e });
+  }
+
+  if (data.error) {
+    throw new Error(`JSON-RPC error (${method}): ${data.error.message ?? 'Unknown error'}`);
+  }
+
+  return data.result as T;
+}
+
+function toHexQuantity(value: bigint): string {
+  return `0x${value.toString(16)}`;
+}
+
+function labelForIndex(index: number): string {
+  return DEFAULT_LABELS[index] ?? `Account ${index + 1}`;
+}
+
+function txToRpcObject(tx: mcp.wallet.SignTxInput['tx']): Record<string, unknown> {
+  return {
+    from: tx.from,
+    to: tx.to,
+    data: tx.data,
+    ...(tx.value !== undefined ? { value: toHexQuantity(tx.value) } : {}),
+    ...(tx.gas !== undefined ? { gas: toHexQuantity(tx.gas) } : {}),
+    ...(tx.nonce !== undefined ? { nonce: `0x${tx.nonce.toString(16)}` } : {}),
+    chainId: `0x${tx.chainId.toString(16)}`,
+  };
+}
+
+async function readStateFile(statePath: string): Promise<StateShape> {
+  try {
+    const raw = await readFile(statePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') {
+      return parsed as StateShape;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+async function writeStateFile(statePath: string, state: StateShape): Promise<void> {
+  await mkdir(join(statePath, '..'), { recursive: true });
+  await writeFile(statePath, JSON.stringify(state, null, 2) + '\n', 'utf8');
+}
+
+async function waitForReceipt(
+  chainRpcUrl: string,
+  txHash: string,
+  timeoutMs = 20_000,
+): Promise<RpcReceipt> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const receipt = await rpc<RpcReceipt | null>(chainRpcUrl, 'eth_getTransactionReceipt', [
+      txHash,
+    ]);
+    if (receipt) return receipt;
+    await Bun.sleep(200);
+  }
+  throw new Error(`Timed out waiting for receipt: ${txHash}`);
+}
+
+export function createWalletService(opts: {
+  chainRpcUrl: string;
+  workspaceRoot: string;
+}): WalletService {
+  const statePath = join(opts.workspaceRoot, '.crucible', 'state.json');
+
+  return {
+    async listAccounts() {
+      const addresses = await rpc<string[]>(opts.chainRpcUrl, 'eth_accounts');
+      const balances = await Promise.all(
+        addresses.map((address) =>
+          rpc<string>(opts.chainRpcUrl, 'eth_getBalance', [address, 'latest']),
+        ),
+      );
+
+      return {
+        accounts: addresses.map((address, idx) => ({
+          label: labelForIndex(idx),
+          address: address as `0x${string}`,
+          balance: encodeBigInt(BigInt(balances[idx]!)),
+        })),
+      };
+    },
+
+    async getBalance({ address }) {
+      const balanceHex = await rpc<string>(opts.chainRpcUrl, 'eth_getBalance', [address, 'latest']);
+      return { balance: encodeBigInt(BigInt(balanceHex)) };
+    },
+
+    async signTx({ tx }) {
+      const signedTx = await rpc<string>(opts.chainRpcUrl, 'eth_signTransaction', [
+        txToRpcObject(tx),
+      ]);
+      return { signedTx: signedTx as `0x${string}` };
+    },
+
+    async sendTxLocal({ tx }) {
+      const signedTx = await rpc<string>(opts.chainRpcUrl, 'eth_signTransaction', [
+        txToRpcObject(tx),
+      ]);
+      const txHash = await rpc<string>(opts.chainRpcUrl, 'eth_sendRawTransaction', [signedTx]);
+      const receipt = await waitForReceipt(opts.chainRpcUrl, txHash);
+
+      return {
+        txHash: txHash as `0x${string}`,
+        gasUsed: encodeBigInt(BigInt(receipt.gasUsed)),
+        status: receipt.status === '0x1' ? 'success' : 'reverted',
+      };
+    },
+
+    async switchAccount({ label }) {
+      const accounts = await this.listAccounts();
+      const selected = accounts.accounts.find((entry) => entry.label === label);
+      if (!selected) {
+        throw new Error(`Unknown account label: ${label}`);
+      }
+
+      const state = await readStateFile(statePath);
+      state.wallet = {
+        ...(state.wallet ?? {}),
+        activeAccountLabel: label,
+      };
+      await writeStateFile(statePath, state);
+
+      return { active: selected.address };
+    },
+  };
+}

--- a/packages/mcp-wallet/test/service.test.ts
+++ b/packages/mcp-wallet/test/service.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createWalletService } from '../src/service.ts';
+
+const ADDRESS_1 = '0x1111111111111111111111111111111111111111';
+const ADDRESS_2 = '0x2222222222222222222222222222222222222222';
+const TX_HASH = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const SIGNED_TX = '0x1234abcd';
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('mcp-wallet service', () => {
+  let workspaceRoot = '';
+
+  beforeEach(async () => {
+    workspaceRoot = await mkdtemp(join(tmpdir(), 'crucible-mcp-wallet-test-'));
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it('listAccounts returns labeled accounts with decoded balances', async () => {
+    globalThis.fetch = (async (_url, init) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as {
+        method?: string;
+        params?: unknown[];
+      };
+      switch (body.method) {
+        case 'eth_accounts':
+          return jsonResponse({ jsonrpc: '2.0', id: 1, result: [ADDRESS_1, ADDRESS_2] });
+        case 'eth_getBalance': {
+          const address = String(body.params?.[0] ?? '');
+          return jsonResponse({
+            jsonrpc: '2.0',
+            id: 1,
+            result: address === ADDRESS_1 ? '0x1' : '0x2',
+          });
+        }
+        default:
+          return jsonResponse({ jsonrpc: '2.0', id: 1, error: { message: 'unexpected method' } });
+      }
+    }) as typeof fetch;
+
+    const service = createWalletService({ chainRpcUrl: 'http://rpc.local', workspaceRoot });
+    const result = await service.listAccounts();
+
+    expect(result.accounts).toHaveLength(2);
+    expect(result.accounts[0]?.label).toBe('Account 1');
+    expect(result.accounts[1]?.label).toBe('Account 2');
+    expect(result.accounts[0]?.balance).toBe('1');
+    expect(result.accounts[1]?.balance).toBe('2');
+  });
+
+  it('sendTxLocal signs, broadcasts, and returns receipt-derived status', async () => {
+    globalThis.fetch = (async (_url, init) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as { method?: string };
+
+      switch (body.method) {
+        case 'eth_signTransaction':
+          return jsonResponse({ jsonrpc: '2.0', id: 1, result: SIGNED_TX });
+        case 'eth_sendRawTransaction':
+          return jsonResponse({ jsonrpc: '2.0', id: 1, result: TX_HASH });
+        case 'eth_getTransactionReceipt':
+          return jsonResponse({
+            jsonrpc: '2.0',
+            id: 1,
+            result: {
+              gasUsed: '0x5208',
+              status: '0x1',
+            },
+          });
+        default:
+          return jsonResponse({ jsonrpc: '2.0', id: 1, error: { message: 'unexpected method' } });
+      }
+    }) as typeof fetch;
+
+    const service = createWalletService({ chainRpcUrl: 'http://rpc.local', workspaceRoot });
+    const out = await service.sendTxLocal({
+      tx: {
+        from: ADDRESS_1,
+        to: ADDRESS_2,
+        data: '0x',
+        chainId: 31337,
+      },
+    });
+
+    expect(out.txHash).toBe(TX_HASH);
+    expect(out.gasUsed).toBe('21000');
+    expect(out.status).toBe('success');
+  });
+
+  it('switchAccount persists activeAccountLabel in .crucible/state.json', async () => {
+    globalThis.fetch = (async (_url, init) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as {
+        method?: string;
+        params?: unknown[];
+      };
+
+      switch (body.method) {
+        case 'eth_accounts':
+          return jsonResponse({ jsonrpc: '2.0', id: 1, result: [ADDRESS_1, ADDRESS_2] });
+        case 'eth_getBalance':
+          return jsonResponse({ jsonrpc: '2.0', id: 1, result: '0x1' });
+        default:
+          return jsonResponse({ jsonrpc: '2.0', id: 1, error: { message: 'unexpected method' } });
+      }
+    }) as typeof fetch;
+
+    const service = createWalletService({ chainRpcUrl: 'http://rpc.local', workspaceRoot });
+    const switched = await service.switchAccount({ label: 'Account 2' });
+    expect(switched.active).toBe(ADDRESS_2);
+
+    const statePath = join(workspaceRoot, '.crucible', 'state.json');
+    const raw = await readFile(statePath, 'utf8');
+    const state = JSON.parse(raw) as { wallet?: { activeAccountLabel?: string } };
+    expect(state.wallet?.activeAccountLabel).toBe('Account 2');
+  });
+});

--- a/packages/mcp-wallet/tsconfig.json
+++ b/packages/mcp-wallet/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/types/src/mcp/compiler.ts
+++ b/packages/types/src/mcp/compiler.ts
@@ -6,32 +6,12 @@ import { z } from 'zod';
 import { AbiSchema, CompiledContractSchema, CompilerMessageSchema } from '../compiler.ts';
 import { HexSchema } from '../primitives.ts';
 
-export const CompileInputSchema = z
-  .object({
-    /** Workspace-relative path of the source file to compile. Mutually exclusive with `source`. */
-    sourcePath: z.string().min(1).optional(),
-    /**
-     * Inline Solidity source code to compile directly without a file on disk.
-     * Mutually exclusive with `sourcePath`. Use `fileName` to control the source name
-     * that appears in artifact identifiers (e.g. "MyToken.sol:MyToken").
-     */
-    source: z.string().min(1).optional(),
-    /**
-     * Filename to use when compiling inline `source` (must end in .sol).
-     * Defaults to "Inline.sol". Ignored when `sourcePath` is provided.
-     */
-    fileName: z
-      .string()
-      .min(1)
-      .regex(/\.sol$/, 'fileName must end in .sol')
-      .optional(),
-    /** Optional compiler settings override (Hardhat-subset: version, optimizer, evmVersion). */
-    settings: z.record(z.string(), z.unknown()).optional(),
-  })
-  .refine((d) => (d.sourcePath !== undefined) !== (d.source !== undefined), {
-    message:
-      'Provide exactly one of sourcePath (workspace file) or source (inline code), not both.',
-  });
+export const CompileInputSchema = z.object({
+  /** Workspace-relative path of the source file to compile (e.g. "contracts/Counter.sol"). */
+  sourcePath: z.string().min(1),
+  /** Optional compiler settings override (Hardhat-subset: version, optimizer, evmVersion). */
+  settings: z.record(z.string(), z.unknown()).optional(),
+});
 export const CompileOutputSchema = z.object({
   contracts: z.array(CompiledContractSchema),
   /** All warnings emitted across every contract in the file, deduplicated by message text. */

--- a/packages/types/src/mcp/deployer.ts
+++ b/packages/types/src/mcp/deployer.ts
@@ -18,13 +18,19 @@ const TxRequestSchema = z.object({
 });
 export type TxRequest = z.infer<typeof TxRequestSchema>;
 
+/**
+ * Deploy by compiled contract name — bytecode is auto-fetched from mcp-compiler.
+ * Run compile first, then pass the contract name here.
+ */
 export const DeployLocalInputSchema = z.object({
-  bytecode: HexSchema,
+  /** Compiled contract name (e.g. "Counter"). Compile first via compiler-mcp. */
+  contractName: z.string().min(1),
   /** Encoded constructor calldata appended to the bytecode. May be empty `0x`. */
   constructorData: HexSchema,
   sender: AddressSchema.optional(),
   value: BigIntStringSchema.optional(),
 });
+
 export const DeployLocalOutputSchema = z.object({
   address: AddressSchema,
   txHash: HashSchema,

--- a/packages/types/src/runtime.ts
+++ b/packages/types/src/runtime.ts
@@ -76,8 +76,8 @@ export const ToolExecRequestSchema = z.object({
   ...corr,
   type: z.literal('tool_exec'),
   workspaceId: WorkspaceIdSchema,
-  /** Logical MCP server name: `chain` | `compiler` | `deployer` | `wallet` | `terminal`. */
-  server: z.enum(['chain', 'compiler', 'deployer', 'wallet', 'terminal']),
+  /** Logical MCP server name: `chain` | `compiler` | `deployer` | `wallet` | `terminal` | `memory` | `mesh`. */
+  server: z.enum(['chain', 'compiler', 'deployer', 'wallet', 'terminal', 'memory', 'mesh']),
   tool: z.string().min(1),
   args: z.unknown(),
 });


### PR DESCRIPTION
Closes: #12 

This pull request introduces the new `@crucible/mcp-deployer` package, which provides an HTTP server for local-chain contract deployment, simulation, tracing, and read calls. The implementation includes configuration via environment variables, OpenAPI-typed REST endpoints, and integration with the MCP protocol. The most important changes are grouped below:

---

**New Package Initialization and Configuration**

* Added a new `@crucible/mcp-deployer` package with `package.json` specifying dependencies, scripts, and project metadata for a Bun/TypeScript-based HTTP server.
* Introduced a `.env.example` file documenting environment variables for server configuration, such as port, chain RPC URL, and workspace root.

**Server and Protocol Implementation**

* Implemented the main entry point (`src/index.ts`) to start an OpenAPIHono HTTP server, define REST endpoints for deploy, simulate, trace, and call operations, and expose the MCP protocol transport. Includes request logging and host header validation.
* Added `src/server.ts` to register MCP protocol tools for deploy, simulate, trace, and call, each with input schemas, logging, and error handling.

**Service Logic and Chain Integration**

* Developed `src/service.ts` containing the core logic for contract deployment, transaction simulation, tracing, and read-only calls, including robust JSON-RPC error handling, revert reason decoding, and workspace path containment checks.