### PR TITLE
feat: enhance MCP Devtools with event handling and TypeScript support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -195,6 +195,17 @@
         "typescript": "^5.7.3",
       },
     },
+    "packages/mcp-devtools": {
+      "name": "@crucible/mcp-devtools",
+      "version": "0.0.0",
+      "dependencies": {
+        "hono": "^4.0.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.6",
+        "typescript": "^5.7.3",
+      },
+    },
     "packages/mcp-memory": {
       "name": "@crucible/mcp-memory",
       "version": "0.0.0",
@@ -343,6 +354,8 @@
     "@crucible/mcp-compiler": ["@crucible/mcp-compiler@workspace:packages/mcp-compiler"],
 
     "@crucible/mcp-deployer": ["@crucible/mcp-deployer@workspace:packages/mcp-deployer"],
+
+    "@crucible/mcp-devtools": ["@crucible/mcp-devtools@workspace:packages/mcp-devtools"],
 
     "@crucible/mcp-memory": ["@crucible/mcp-memory@workspace:packages/mcp-memory"],
 

--- a/packages/backend/runtime/Dockerfile
+++ b/packages/backend/runtime/Dockerfile
@@ -14,7 +14,7 @@ FROM oven/bun:1.3.6 AS base
 
 # git is required by hardhat's solc compiler downloads.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        git ca-certificates \
+        git ca-certificates curl \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -29,6 +29,7 @@ COPY packages/mcp-compiler/package.json packages/mcp-compiler/
 COPY packages/mcp-deployer/package.json packages/mcp-deployer/
 COPY packages/mcp-wallet/package.json packages/mcp-wallet/
 COPY packages/mcp-memory/package.json packages/mcp-memory/
+COPY packages/mcp-devtools/package.json packages/mcp-devtools/
 
 RUN bun install --frozen-lockfile || bun install
 
@@ -39,6 +40,7 @@ COPY packages/mcp-compiler ./packages/mcp-compiler
 COPY packages/mcp-deployer ./packages/mcp-deployer
 COPY packages/mcp-wallet ./packages/mcp-wallet
 COPY packages/mcp-memory ./packages/mcp-memory
+COPY packages/mcp-devtools ./packages/mcp-devtools
 
 # /workspace is the per-workspace bind mount target.
 WORKDIR /workspace
@@ -52,10 +54,11 @@ ENV CHAIN_MCP_PORT=3100 \
     WALLET_MCP_PORT=3103 \
     MEMORY_MCP_PORT=3104 \
     TERMINAL_MCP_PORT=3105 \
+    DEVTOOLS_MCP_PORT=3107 \
     WORKSPACE_ROOT=/workspace \
     ALLOWED_HOSTS=host.docker.internal
 
-EXPOSE 3100 3101 3102 3103 3104 3105
+EXPOSE 3100 3101 3102 3103 3104 3105 3107
 
 COPY packages/backend/runtime/entrypoint.sh /usr/local/bin/crucible-runtime-entrypoint
 RUN chmod +x /usr/local/bin/crucible-runtime-entrypoint

--- a/packages/backend/runtime/entrypoint.sh
+++ b/packages/backend/runtime/entrypoint.sh
@@ -15,6 +15,22 @@ mkdir -p contracts frontend .crucible/artifacts .crucible/logs
 
 log() { echo "[runtime] $*"; }
 
+emit_container_event() {
+    local subtype="$1"
+    local message="$2"
+    local ts
+    ts=$(date +%s%3N)
+    local payload
+    payload=$(printf '{"type":"container","ts":%s,"subtype":"%s","message":"%s"}' "$ts" "$subtype" "$message")
+    curl -sS -X POST "http://127.0.0.1:${DEVTOOLS_MCP_PORT}/event" \
+        -H 'content-type: application/json' \
+        -d "$payload" >/dev/null 2>&1 || true
+}
+
+log "starting mcp-devtools on port ${DEVTOOLS_MCP_PORT}"
+bun run --cwd /app/packages/mcp-devtools start &
+devtools_pid=$!
+
 # Run both servers as background jobs so we can supervise them. We rely on
 # Bun's hot-restart-free `start` script in each package.
 log "starting mcp-chain on port ${CHAIN_MCP_PORT}"
@@ -36,25 +52,28 @@ wallet_pid=$!
 log "starting mcp-memory on port ${MEMORY_MCP_PORT}"
 bun run --cwd /app/packages/mcp-memory start &
 memory_pid=$!
+emit_container_event "runtime_start" "services booted"
 
 shutdown() {
     log "received shutdown — terminating services"
-    kill -TERM "${chain_pid}" "${compiler_pid}" "${deployer_pid}" "${wallet_pid}" "${memory_pid}" 2>/dev/null || true
-    wait "${chain_pid}" "${compiler_pid}" "${deployer_pid}" "${wallet_pid}" "${memory_pid}" 2>/dev/null || true
+    emit_container_event "runtime_shutdown" "received shutdown signal"
+    kill -TERM "${devtools_pid}" "${chain_pid}" "${compiler_pid}" "${deployer_pid}" "${wallet_pid}" "${memory_pid}" 2>/dev/null || true
+    wait "${devtools_pid}" "${chain_pid}" "${compiler_pid}" "${deployer_pid}" "${wallet_pid}" "${memory_pid}" 2>/dev/null || true
     exit 0
 }
 trap shutdown TERM INT
 
 # If any service exits, propagate the failure to the container.
 while true; do
-    for pair in "chain_pid:mcp-chain" "compiler_pid:mcp-compiler" "deployer_pid:mcp-deployer" "wallet_pid:mcp-wallet" "memory_pid:mcp-memory"; do
+    for pair in "devtools_pid:mcp-devtools" "chain_pid:mcp-chain" "compiler_pid:mcp-compiler" "deployer_pid:mcp-deployer" "wallet_pid:mcp-wallet" "memory_pid:mcp-memory"; do
         varname="${pair%%:*}"
         label="${pair##*:}"
         eval pid=\$$varname
         if ! kill -0 "${pid}" 2>/dev/null; then
             log "${label} exited unexpectedly" >&2
-            kill -TERM "${chain_pid}" "${compiler_pid}" "${deployer_pid}" "${wallet_pid}" "${memory_pid}" 2>/dev/null || true
-            wait "${chain_pid}" "${compiler_pid}" "${deployer_pid}" "${wallet_pid}" "${memory_pid}" 2>/dev/null || true
+            emit_container_event "service_crash" "${label} exited unexpectedly"
+            kill -TERM "${devtools_pid}" "${chain_pid}" "${compiler_pid}" "${deployer_pid}" "${wallet_pid}" "${memory_pid}" 2>/dev/null || true
+            wait "${devtools_pid}" "${chain_pid}" "${compiler_pid}" "${deployer_pid}" "${wallet_pid}" "${memory_pid}" 2>/dev/null || true
             exit 1
         fi
     done

--- a/packages/backend/src/api/workspace.ts
+++ b/packages/backend/src/api/workspace.ts
@@ -23,8 +23,12 @@ import { prisma } from '../lib/prisma';
 import { randomUUID } from 'node:crypto';
 import { Prisma } from '../generated/prisma/client';
 import { createApiErrorBody } from '../lib/api-error';
-import { ensureWorkspaceContainer } from '../lib/runtime-docker';
 import { startPreview, getPreviewUrl } from '../lib/preview-manager';
+import {
+  ensureWorkspaceContainer,
+  getWorkspaceContainerPorts,
+  runtimeServiceBaseUrl,
+} from '../lib/runtime-docker';
 import { publishAgentEvent, nextAgentSeq } from '../lib/agent-bus';
 import { requireSession } from '../lib/auth';
 
@@ -374,4 +378,46 @@ export const workspaceApi = workspaceApiBase
         500,
       );
     }
+  })
+  .get('/workspace/:id/devtools/events', async (c) => {
+    const id = c.req.param('id');
+    const userId = c.get('userId');
+
+    const workspace = await prisma.workspace.findUnique({
+      where: { id },
+      select: { id: true, userId: true },
+    });
+    if (!workspace || workspace.userId !== userId) {
+      return c.json(createApiErrorBody('not_found', 'Workspace not found'), 404);
+    }
+
+    const ports = await getWorkspaceContainerPorts(workspace.id).catch(() => null);
+    if (!ports?.devtools) {
+      return c.json({ error: 'devtools not ready' }, 503);
+    }
+
+    const upstreamUrl = `${runtimeServiceBaseUrl(ports.devtools)}/events`;
+    let upstream: Response;
+    try {
+      upstream = await fetch(upstreamUrl, {
+        headers: { accept: 'text/event-stream' },
+        signal: c.req.raw.signal,
+      });
+    } catch {
+      return c.json({ error: 'devtools not ready' }, 503);
+    }
+
+    if (!upstream.ok || !upstream.body) {
+      return c.json({ error: 'devtools not ready' }, 503);
+    }
+
+    return new Response(upstream.body, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        'X-Accel-Buffering': 'no',
+      },
+    });
   });

--- a/packages/backend/src/lib/runtime-docker.ts
+++ b/packages/backend/src/lib/runtime-docker.ts
@@ -33,6 +33,7 @@ const CONTAINER_DEPLOYER_PORT = 3102;
 const CONTAINER_WALLET_PORT = 3103;
 const CONTAINER_MEMORY_PORT = 3104;
 const CONTAINER_TERMINAL_PORT = 3105;
+const CONTAINER_DEVTOOLS_PORT = 3107;
 
 const READINESS_TIMEOUT_MS = Number(process.env['CRUCIBLE_RUNTIME_READY_TIMEOUT_MS'] ?? '60000');
 const READINESS_INTERVAL_MS = Number(process.env['CRUCIBLE_RUNTIME_READY_INTERVAL_MS'] ?? '500');
@@ -320,6 +321,7 @@ export type WorkspaceRuntimePorts = {
   wallet: number | null;
   memory: number | null;
   terminal: number | null;
+  devtools: number | null;
 };
 
 export type EnsureWorkspaceContainerResult = {
@@ -412,6 +414,7 @@ export async function ensureWorkspaceContainer(
             `DEPLOYER_MCP_PORT=${CONTAINER_DEPLOYER_PORT}`,
             `WALLET_MCP_PORT=${CONTAINER_WALLET_PORT}`,
             `MEMORY_MCP_PORT=${CONTAINER_MEMORY_PORT}`,
+            `DEVTOOLS_MCP_PORT=${CONTAINER_DEVTOOLS_PORT}`,
             `WORKSPACE_ROOT=${workspaceDir}`,
           ],
           ExposedPorts: {
@@ -421,6 +424,7 @@ export async function ensureWorkspaceContainer(
             [`${CONTAINER_WALLET_PORT}/tcp`]: {},
             [`${CONTAINER_MEMORY_PORT}/tcp`]: {},
             [`${CONTAINER_TERMINAL_PORT}/tcp`]: {},
+            [`${CONTAINER_DEVTOOLS_PORT}/tcp`]: {},
           },
           HostConfig: {
             RestartPolicy: { Name: 'unless-stopped' },
@@ -433,6 +437,7 @@ export async function ensureWorkspaceContainer(
               [`${CONTAINER_WALLET_PORT}/tcp`]: [{ HostPort: '' }],
               [`${CONTAINER_MEMORY_PORT}/tcp`]: [{ HostPort: '' }],
               [`${CONTAINER_TERMINAL_PORT}/tcp`]: [{ HostPort: '' }],
+              [`${CONTAINER_DEVTOOLS_PORT}/tcp`]: [{ HostPort: '' }],
             },
           },
         }),
@@ -467,6 +472,7 @@ export async function ensureWorkspaceContainer(
     wallet: freshInspect ? extractHostPort(freshInspect, CONTAINER_WALLET_PORT) : null,
     memory: freshInspect ? extractHostPort(freshInspect, CONTAINER_MEMORY_PORT) : null,
     terminal: freshInspect ? extractHostPort(freshInspect, CONTAINER_TERMINAL_PORT) : null,
+    devtools: freshInspect ? extractHostPort(freshInspect, CONTAINER_DEVTOOLS_PORT) : null,
   };
 
   const ready = await waitForRuntimeReady(ports);
@@ -493,6 +499,7 @@ export async function getWorkspaceContainerPorts(
     wallet: extractHostPort(inspect, CONTAINER_WALLET_PORT),
     memory: extractHostPort(inspect, CONTAINER_MEMORY_PORT),
     terminal: extractHostPort(inspect, CONTAINER_TERMINAL_PORT),
+    devtools: extractHostPort(inspect, CONTAINER_DEVTOOLS_PORT),
   };
 }
 

--- a/packages/mcp-chain/src/index.ts
+++ b/packages/mcp-chain/src/index.ts
@@ -151,6 +151,22 @@ const mcpServer = createChainServer(WORKSPACE_ID, {
 
 type Env = { Variables: { parsedBody: unknown } };
 
+type McpToolsCallBody = {
+  method?: string;
+  params?: {
+    name?: string;
+    arguments?: unknown;
+  };
+};
+
+type McpResponseBody = {
+  result?: {
+    structuredContent?: unknown;
+    content?: Array<{ text?: string }>;
+  };
+  error?: unknown;
+};
+
 const transport = new WebStandardStreamableHTTPServerTransport();
 await mcpServer.connect(transport);
 
@@ -210,7 +226,7 @@ app.use('*', async (c, next) => {
   let args: unknown = {};
 
   if (path === '/mcp') {
-    const body: any = c.get('parsedBody');
+    const body = c.get('parsedBody') as McpToolsCallBody | undefined;
     if (body?.method === 'tools/call' && body?.params?.name) {
       tool = body.params.name;
       args = body.params.arguments ?? {};
@@ -233,7 +249,7 @@ app.use('*', async (c, next) => {
   let result: unknown = { status: c.res?.status ?? 0 };
 
   try {
-    const json: any = await c.res.clone().json();
+    const json = (await c.res.clone().json()) as McpResponseBody;
     if (path === '/mcp') {
       if (json?.result) {
         if (json.result.structuredContent) {

--- a/packages/mcp-chain/src/index.ts
+++ b/packages/mcp-chain/src/index.ts
@@ -16,7 +16,7 @@ import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/
 import { hostHeaderValidation } from '@modelcontextprotocol/hono';
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
 import { z } from 'zod';
-import { mcp, encodeBigInt, AllowedRpcMethodSchema } from '@crucible/types';
+import { mcp, encodeBigInt, createDevtoolsReporter, AllowedRpcMethodSchema } from '@crucible/types';
 import {
   StartNodeInputSchema,
   StartNodeOutputSchema,
@@ -36,6 +36,7 @@ const PORT = process.env['CHAIN_MCP_PORT']
 
 const WORKSPACE_ID = process.env['WORKSPACE_ID'] ?? 'default';
 const DEFAULT_FORK_RPC_URL = process.env['DEFAULT_FORK_RPC_URL'];
+const devtools = createDevtoolsReporter('chain');
 
 console.log(`[mcp-chain] starting on port ${PORT} (workspaceId: ${WORKSPACE_ID})`);
 if (DEFAULT_FORK_RPC_URL) {
@@ -191,6 +192,73 @@ app.use('*', async (c, next) => {
   const status = c.res?.status ?? 0;
   const logFn = status >= 500 ? console.error : status >= 400 ? console.warn : console.log;
   logFn(`[mcp-chain] \u2190 ${status} (${ms}ms)`);
+});
+
+function chainToolForPath(path: string): string | null {
+  if (path === '/start_node') return 'start_node';
+  if (path === '/state') return 'get_state';
+  if (path === '/snapshot') return 'snapshot';
+  if (path === '/revert') return 'revert';
+  if (path === '/mine') return 'mine';
+  if (path === '/fork') return 'fork';
+  return null;
+}
+
+app.use('*', async (c, next) => {
+  const path = new URL(c.req.url).pathname;
+  let tool = chainToolForPath(path);
+  let args: unknown = {};
+
+  if (path === '/mcp') {
+    const body: any = c.get('parsedBody');
+    if (body?.method === 'tools/call' && body?.params?.name) {
+      tool = body.params.name;
+      args = body.params.arguments ?? {};
+    }
+  } else if (tool) {
+    args = c.req.method === 'GET' ? {} : c.get('parsedBody');
+  }
+
+  if (!tool) {
+    await next();
+    return;
+  }
+
+  const startedAt = Date.now();
+  void devtools.emitToolCall(tool, args ?? {});
+  await next();
+
+  const durationMs = Date.now() - startedAt;
+  const ok = (c.res?.status ?? 500) < 400;
+  let result: unknown = { status: c.res?.status ?? 0 };
+
+  try {
+    const json: any = await c.res.clone().json();
+    if (path === '/mcp') {
+      if (json?.result) {
+        if (json.result.structuredContent) {
+          result = json.result.structuredContent;
+        } else if (json.result.content?.[0]?.text) {
+          try {
+            result = JSON.parse(json.result.content[0].text);
+          } catch {
+            result = json.result;
+          }
+        } else {
+          result = json.result;
+        }
+      } else if (json?.error) {
+        result = json.error;
+      } else {
+        result = json;
+      }
+    } else {
+      result = json;
+    }
+  } catch {
+    // Non-JSON responses still get traced with status.
+  }
+  void devtools.emitToolResult(tool, ok, result, durationMs);
 });
 
 // REST route handlers

--- a/packages/mcp-chain/src/index.ts
+++ b/packages/mcp-chain/src/index.ts
@@ -16,7 +16,14 @@ import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/
 import { hostHeaderValidation } from '@modelcontextprotocol/hono';
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
 import { z } from 'zod';
-import { mcp, encodeBigInt, createDevtoolsReporter, AllowedRpcMethodSchema } from '@crucible/types';
+import {
+  mcp,
+  encodeBigInt,
+  createDevtoolsReporter,
+  type McpToolsCallBody,
+  type McpResponseBody,
+  AllowedRpcMethodSchema,
+} from '@crucible/types';
 import {
   StartNodeInputSchema,
   StartNodeOutputSchema,
@@ -150,22 +157,6 @@ const mcpServer = createChainServer(WORKSPACE_ID, {
 });
 
 type Env = { Variables: { parsedBody: unknown } };
-
-type McpToolsCallBody = {
-  method?: string;
-  params?: {
-    name?: string;
-    arguments?: unknown;
-  };
-};
-
-type McpResponseBody = {
-  result?: {
-    structuredContent?: unknown;
-    content?: Array<{ text?: string }>;
-  };
-  error?: unknown;
-};
 
 const transport = new WebStandardStreamableHTTPServerTransport();
 await mcpServer.connect(transport);

--- a/packages/mcp-compiler/src/index.ts
+++ b/packages/mcp-compiler/src/index.ts
@@ -119,6 +119,22 @@ const mcpServer = createCompilerServer({
 
 type Env = { Variables: { parsedBody: unknown } };
 
+type McpToolsCallBody = {
+  method?: string;
+  params?: {
+    name?: string;
+    arguments?: unknown;
+  };
+};
+
+type McpResponseBody = {
+  result?: {
+    structuredContent?: unknown;
+    content?: Array<{ text?: string }>;
+  };
+  error?: unknown;
+};
+
 const transport = new WebStandardStreamableHTTPServerTransport();
 await mcpServer.connect(transport);
 
@@ -176,7 +192,7 @@ app.use('*', async (c, next) => {
   let args: unknown = {};
 
   if (path === '/mcp') {
-    const body: any = c.get('parsedBody');
+    const body = c.get('parsedBody') as McpToolsCallBody | undefined;
     if (body?.method === 'tools/call' && body?.params?.name) {
       tool = body.params.name;
       args = body.params.arguments ?? {};
@@ -199,7 +215,7 @@ app.use('*', async (c, next) => {
   let result: unknown = { status: c.res?.status ?? 0 };
 
   try {
-    const json: any = await c.res.clone().json();
+    const json = (await c.res.clone().json()) as McpResponseBody;
     if (path === '/mcp') {
       if (json?.result) {
         if (json.result.structuredContent) {

--- a/packages/mcp-compiler/src/index.ts
+++ b/packages/mcp-compiler/src/index.ts
@@ -20,7 +20,12 @@ import { join } from 'node:path';
 
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
 import { z } from 'zod';
-import { mcp, createDevtoolsReporter } from '@crucible/types';
+import {
+  mcp,
+  createDevtoolsReporter,
+  type McpToolsCallBody,
+  type McpResponseBody,
+} from '@crucible/types';
 import {
   CompileInputSchema,
   CompileOutputSchema,
@@ -118,22 +123,6 @@ const mcpServer = createCompilerServer({
 });
 
 type Env = { Variables: { parsedBody: unknown } };
-
-type McpToolsCallBody = {
-  method?: string;
-  params?: {
-    name?: string;
-    arguments?: unknown;
-  };
-};
-
-type McpResponseBody = {
-  result?: {
-    structuredContent?: unknown;
-    content?: Array<{ text?: string }>;
-  };
-  error?: unknown;
-};
 
 const transport = new WebStandardStreamableHTTPServerTransport();
 await mcpServer.connect(transport);

--- a/packages/mcp-compiler/src/index.ts
+++ b/packages/mcp-compiler/src/index.ts
@@ -20,7 +20,7 @@ import { join } from 'node:path';
 
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
 import { z } from 'zod';
-import { mcp } from '@crucible/types';
+import { mcp, createDevtoolsReporter } from '@crucible/types';
 import {
   CompileInputSchema,
   CompileOutputSchema,
@@ -40,6 +40,7 @@ const PORT = process.env['COMPILER_MCP_PORT']
 
 const WORKSPACE_ROOT = process.env['WORKSPACE_ROOT'] ?? process.cwd();
 const SOLC_VERSION = process.env['SOLC_VERSION'];
+const devtools = createDevtoolsReporter('compiler');
 
 console.log(`[mcp-compiler] starting on port ${PORT} (workspaceRoot: ${WORKSPACE_ROOT})`);
 
@@ -159,6 +160,71 @@ app.use('*', async (c, next) => {
   const status = c.res?.status ?? 0;
   const logFn = status >= 500 ? console.error : status >= 400 ? console.warn : console.log;
   logFn(`[mcp-compiler] \u2190 ${status} (${ms}ms)`);
+});
+
+function compilerToolForPath(path: string): string | null {
+  if (path === '/compile') return 'compile';
+  if (path.startsWith('/abi/')) return 'get_abi';
+  if (path.startsWith('/bytecode/')) return 'get_bytecode';
+  if (path === '/contracts') return 'list_contracts';
+  return null;
+}
+
+app.use('*', async (c, next) => {
+  const path = new URL(c.req.url).pathname;
+  let tool = compilerToolForPath(path);
+  let args: unknown = {};
+
+  if (path === '/mcp') {
+    const body: any = c.get('parsedBody');
+    if (body?.method === 'tools/call' && body?.params?.name) {
+      tool = body.params.name;
+      args = body.params.arguments ?? {};
+    }
+  } else if (tool) {
+    args = c.req.method === 'GET' ? {} : c.get('parsedBody');
+  }
+
+  if (!tool) {
+    await next();
+    return;
+  }
+
+  const startedAt = Date.now();
+  void devtools.emitToolCall(tool, args ?? {});
+  await next();
+
+  const durationMs = Date.now() - startedAt;
+  const ok = (c.res?.status ?? 500) < 400;
+  let result: unknown = { status: c.res?.status ?? 0 };
+
+  try {
+    const json: any = await c.res.clone().json();
+    if (path === '/mcp') {
+      if (json?.result) {
+        if (json.result.structuredContent) {
+          result = json.result.structuredContent;
+        } else if (json.result.content?.[0]?.text) {
+          try {
+            result = JSON.parse(json.result.content[0].text);
+          } catch {
+            result = json.result;
+          }
+        } else {
+          result = json.result;
+        }
+      } else if (json?.error) {
+        result = json.error;
+      } else {
+        result = json;
+      }
+    } else {
+      result = json;
+    }
+  } catch {
+    // Non-JSON responses still get traced with status.
+  }
+  void devtools.emitToolResult(tool, ok, result, durationMs);
 });
 
 // REST route handlers

--- a/packages/mcp-deployer/src/index.ts
+++ b/packages/mcp-deployer/src/index.ts
@@ -20,7 +20,7 @@ import { hostHeaderValidation } from '@modelcontextprotocol/hono';
 import { existsSync } from 'node:fs';
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
 import { z } from 'zod';
-import { mcp } from '@crucible/types';
+import { mcp, createDevtoolsReporter } from '@crucible/types';
 import {
   DeployLocalInputSchema,
   SimulateLocalInputSchema,
@@ -37,6 +37,7 @@ const PORT = process.env['DEPLOYER_MCP_PORT']
 const CHAIN_RPC_URL = process.env['CHAIN_RPC_URL'] ?? 'http://localhost:3100/rpc';
 const COMPILER_URL = process.env['COMPILER_URL'] ?? 'http://localhost:3101';
 const WORKSPACE_ROOT = process.env['WORKSPACE_ROOT'] ?? process.cwd();
+const devtools = createDevtoolsReporter('deployer');
 
 console.log(
   `[mcp-deployer] starting on port ${PORT} (workspaceRoot: ${WORKSPACE_ROOT}, chainRpcUrl: ${CHAIN_RPC_URL}, compilerUrl: ${COMPILER_URL})`,
@@ -222,6 +223,71 @@ app.use('*', async (c, next) => {
   const status = c.res?.status ?? 0;
   const logFn = status >= 500 ? console.error : status >= 400 ? console.warn : console.log;
   logFn(`[mcp-deployer] ← ${status} (${ms}ms)`);
+});
+
+function deployerToolForPath(path: string): string | null {
+  if (path === '/deploy_local') return 'deploy_local';
+  if (path === '/simulate_local') return 'simulate_local';
+  if (path === '/trace') return 'trace';
+  if (path === '/call') return 'call';
+  return null;
+}
+
+app.use('*', async (c, next) => {
+  const path = new URL(c.req.url).pathname;
+  let tool = deployerToolForPath(path);
+  let args: unknown = {};
+
+  if (path === '/mcp') {
+    const body: any = c.get('parsedBody');
+    if (body?.method === 'tools/call' && body?.params?.name) {
+      tool = body.params.name;
+      args = body.params.arguments ?? {};
+    }
+  } else if (tool) {
+    args = c.req.method === 'GET' ? {} : c.get('parsedBody');
+  }
+
+  if (!tool) {
+    await next();
+    return;
+  }
+
+  const startedAt = Date.now();
+  void devtools.emitToolCall(tool, args ?? {});
+  await next();
+
+  const durationMs = Date.now() - startedAt;
+  const ok = (c.res?.status ?? 500) < 400;
+  let result: unknown = { status: c.res?.status ?? 0 };
+
+  try {
+    const json: any = await c.res.clone().json();
+    if (path === '/mcp') {
+      if (json?.result) {
+        if (json.result.structuredContent) {
+          result = json.result.structuredContent;
+        } else if (json.result.content?.[0]?.text) {
+          try {
+            result = JSON.parse(json.result.content[0].text);
+          } catch {
+            result = json.result;
+          }
+        } else {
+          result = json.result;
+        }
+      } else if (json?.error) {
+        result = json.error;
+      } else {
+        result = json;
+      }
+    } else {
+      result = json;
+    }
+  } catch {
+    // Non-JSON responses still get traced with status.
+  }
+  void devtools.emitToolResult(tool, ok, result, durationMs);
 });
 
 app.openapi(deployLocalRoute, async (c) => {

--- a/packages/mcp-deployer/src/index.ts
+++ b/packages/mcp-deployer/src/index.ts
@@ -20,7 +20,12 @@ import { hostHeaderValidation } from '@modelcontextprotocol/hono';
 import { existsSync } from 'node:fs';
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
 import { z } from 'zod';
-import { mcp, createDevtoolsReporter } from '@crucible/types';
+import {
+  mcp,
+  createDevtoolsReporter,
+  type McpToolsCallBody,
+  type McpResponseBody,
+} from '@crucible/types';
 import {
   DeployLocalInputSchema,
   SimulateLocalInputSchema,
@@ -185,22 +190,6 @@ const mcpServer = createDeployerServer({
 });
 
 type Env = { Variables: { parsedBody: unknown } };
-
-type McpToolsCallBody = {
-  method?: string;
-  params?: {
-    name?: string;
-    arguments?: unknown;
-  };
-};
-
-type McpResponseBody = {
-  result?: {
-    structuredContent?: unknown;
-    content?: Array<{ text?: string }>;
-  };
-  error?: unknown;
-};
 
 const transport = new WebStandardStreamableHTTPServerTransport();
 await mcpServer.connect(transport);

--- a/packages/mcp-deployer/src/index.ts
+++ b/packages/mcp-deployer/src/index.ts
@@ -186,6 +186,22 @@ const mcpServer = createDeployerServer({
 
 type Env = { Variables: { parsedBody: unknown } };
 
+type McpToolsCallBody = {
+  method?: string;
+  params?: {
+    name?: string;
+    arguments?: unknown;
+  };
+};
+
+type McpResponseBody = {
+  result?: {
+    structuredContent?: unknown;
+    content?: Array<{ text?: string }>;
+  };
+  error?: unknown;
+};
+
 const transport = new WebStandardStreamableHTTPServerTransport();
 await mcpServer.connect(transport);
 
@@ -239,7 +255,7 @@ app.use('*', async (c, next) => {
   let args: unknown = {};
 
   if (path === '/mcp') {
-    const body: any = c.get('parsedBody');
+    const body = c.get('parsedBody') as McpToolsCallBody | undefined;
     if (body?.method === 'tools/call' && body?.params?.name) {
       tool = body.params.name;
       args = body.params.arguments ?? {};
@@ -262,7 +278,7 @@ app.use('*', async (c, next) => {
   let result: unknown = { status: c.res?.status ?? 0 };
 
   try {
-    const json: any = await c.res.clone().json();
+    const json = (await c.res.clone().json()) as McpResponseBody;
     if (path === '/mcp') {
       if (json?.result) {
         if (json.result.structuredContent) {

--- a/packages/mcp-devtools/package.json
+++ b/packages/mcp-devtools/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@crucible/mcp-devtools",
+  "version": "0.0.0",
+  "private": true,
+  "description": "In-container devtools event stream server.",
+  "license": "UNLICENSED",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "dev": "portless --name devtools.crucible --app-port 3107 bun run --hot src/index.ts",
+    "start": "bun run src/index.ts",
+    "build": "echo 'Bun runtime - no compile step'",
+    "check-types": "tsc --noEmit",
+    "lint": "eslint .",
+    "test": "echo 'no tests in @crucible/mcp-devtools'"
+  },
+  "dependencies": {
+    "hono": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.6",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/mcp-devtools/src/index.ts
+++ b/packages/mcp-devtools/src/index.ts
@@ -1,0 +1,123 @@
+import { Hono } from 'hono';
+
+type DevtoolsEvent =
+  | { type: 'tool_call'; ts: number; server: string; tool: string; args: unknown }
+  | {
+      type: 'tool_result';
+      ts: number;
+      server: string;
+      tool: string;
+      ok: boolean;
+      result: unknown;
+      durationMs: number;
+    }
+  | { type: 'container'; ts: number; subtype: string; message: string };
+
+const PORT = process.env['DEVTOOLS_MCP_PORT']
+  ? Number.parseInt(process.env['DEVTOOLS_MCP_PORT'], 10)
+  : 3107;
+const MAX_EVENTS = 500;
+const buffer: DevtoolsEvent[] = [];
+const subscribers = new Set<(event: DevtoolsEvent) => void>();
+
+function appendEvent(event: DevtoolsEvent): void {
+  buffer.push(event);
+  if (buffer.length > MAX_EVENTS) {
+    buffer.splice(0, buffer.length - MAX_EVENTS);
+  }
+  for (const notify of subscribers) {
+    try {
+      notify(event);
+    } catch {
+      // Individual subscriber failures are isolated.
+    }
+  }
+}
+
+function isDevtoolsEvent(value: unknown): value is DevtoolsEvent {
+  if (!value || typeof value !== 'object') return false;
+  const event = value as Record<string, unknown>;
+  if (typeof event['type'] !== 'string' || typeof event['ts'] !== 'number') return false;
+  if (event['type'] === 'tool_call') {
+    return typeof event['server'] === 'string' && typeof event['tool'] === 'string';
+  }
+  if (event['type'] === 'tool_result') {
+    return (
+      typeof event['server'] === 'string' &&
+      typeof event['tool'] === 'string' &&
+      typeof event['ok'] === 'boolean' &&
+      typeof event['durationMs'] === 'number'
+    );
+  }
+  if (event['type'] === 'container') {
+    return typeof event['subtype'] === 'string' && typeof event['message'] === 'string';
+  }
+  return false;
+}
+
+const app = new Hono();
+
+app.post('/event', async (c) => {
+  try {
+    const payload = await c.req.json<unknown>();
+
+    if (isDevtoolsEvent(payload)) {
+      appendEvent(payload);
+    }
+  } catch {
+    // Must never throw from this endpoint.
+  }
+  return c.json({ ok: true });
+});
+
+app.get('/events', (c) => {
+  const encoder = new TextEncoder();
+  const snapshot = [...buffer];
+
+  const body = new ReadableStream({
+    start(controller) {
+      const write = (event: DevtoolsEvent) => {
+        try {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+        } catch {
+          // Client disconnected.
+        }
+      };
+
+      for (const event of snapshot) {
+        write(event);
+      }
+
+      const listener = (event: DevtoolsEvent) => write(event);
+      subscribers.add(listener);
+
+      c.req.raw.signal.addEventListener('abort', () => {
+        subscribers.delete(listener);
+        try {
+          controller.close();
+        } catch {
+          // Already closed.
+        }
+      });
+    },
+    cancel() {
+      // Cancellation cleanup is handled via abort signal listener.
+    },
+  });
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  });
+});
+
+console.log(`[mcp-devtools] starting on port ${PORT}`);
+
+export default {
+  port: PORT,
+  fetch: app.fetch,
+};

--- a/packages/mcp-devtools/tsconfig.json
+++ b/packages/mcp-devtools/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/mcp-memory/src/index.ts
+++ b/packages/mcp-memory/src/index.ts
@@ -18,7 +18,7 @@ import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/
 import { hostHeaderValidation } from '@modelcontextprotocol/hono';
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
 import { z } from 'zod';
-import { mcp } from '@crucible/types';
+import { mcp, createDevtoolsReporter } from '@crucible/types';
 import {
   RecallInputSchema,
   RememberInputSchema,
@@ -33,6 +33,7 @@ const PORT = process.env['MEMORY_MCP_PORT']
   : mcp.DEFAULT_MCP_PORTS.memory;
 
 const WORKSPACE_ROOT = process.env['WORKSPACE_ROOT'] ?? process.cwd();
+const devtools = createDevtoolsReporter('memory');
 
 console.log(`[mcp-memory] starting on port ${PORT} (workspaceRoot: ${WORKSPACE_ROOT})`);
 
@@ -175,6 +176,71 @@ app.use('*', async (c, next) => {
   const status = c.res?.status ?? 0;
   const logFn = status >= 500 ? console.error : status >= 400 ? console.warn : console.log;
   logFn(`[mcp-memory] ← ${status} (${ms}ms)`);
+});
+
+function memoryToolForPath(path: string): string | null {
+  if (path === '/recall') return 'recall';
+  if (path === '/remember') return 'remember';
+  if (path === '/patterns') return 'list_patterns';
+  if (path.startsWith('/provenance/')) return 'provenance';
+  return null;
+}
+
+app.use('*', async (c, next) => {
+  const path = new URL(c.req.url).pathname;
+  let tool = memoryToolForPath(path);
+  let args: unknown = {};
+
+  if (path === '/mcp') {
+    const body: any = c.get('parsedBody');
+    if (body?.method === 'tools/call' && body?.params?.name) {
+      tool = body.params.name;
+      args = body.params.arguments ?? {};
+    }
+  } else if (tool) {
+    args = c.req.method === 'GET' ? {} : c.get('parsedBody');
+  }
+
+  if (!tool) {
+    await next();
+    return;
+  }
+
+  const startedAt = Date.now();
+  void devtools.emitToolCall(tool, args ?? {});
+  await next();
+
+  const durationMs = Date.now() - startedAt;
+  const ok = (c.res?.status ?? 500) < 400;
+  let result: unknown = { status: c.res?.status ?? 0 };
+
+  try {
+    const json: any = await c.res.clone().json();
+    if (path === '/mcp') {
+      if (json?.result) {
+        if (json.result.structuredContent) {
+          result = json.result.structuredContent;
+        } else if (json.result.content?.[0]?.text) {
+          try {
+            result = JSON.parse(json.result.content[0].text);
+          } catch {
+            result = json.result;
+          }
+        } else {
+          result = json.result;
+        }
+      } else if (json?.error) {
+        result = json.error;
+      } else {
+        result = json;
+      }
+    } else {
+      result = json;
+    }
+  } catch {
+    // Non-JSON responses still get traced with status.
+  }
+  void devtools.emitToolResult(tool, ok, result, durationMs);
 });
 
 app.openapi(recallRoute, async (c) => {

--- a/packages/mcp-memory/src/index.ts
+++ b/packages/mcp-memory/src/index.ts
@@ -18,7 +18,12 @@ import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/
 import { hostHeaderValidation } from '@modelcontextprotocol/hono';
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
 import { z } from 'zod';
-import { mcp, createDevtoolsReporter } from '@crucible/types';
+import {
+  mcp,
+  createDevtoolsReporter,
+  type McpToolsCallBody,
+  type McpResponseBody,
+} from '@crucible/types';
 import {
   RecallInputSchema,
   RememberInputSchema,
@@ -138,22 +143,6 @@ const provenanceRoute = createRoute({
 const mcpServer = createMemoryServer({ workspaceRoot: WORKSPACE_ROOT });
 
 type Env = { Variables: { parsedBody: unknown } };
-
-type McpToolsCallBody = {
-  method?: string;
-  params?: {
-    name?: string;
-    arguments?: unknown;
-  };
-};
-
-type McpResponseBody = {
-  result?: {
-    structuredContent?: unknown;
-    content?: Array<{ text?: string }>;
-  };
-  error?: unknown;
-};
 
 const transport = new WebStandardStreamableHTTPServerTransport();
 await mcpServer.connect(transport);

--- a/packages/mcp-memory/src/index.ts
+++ b/packages/mcp-memory/src/index.ts
@@ -139,6 +139,22 @@ const mcpServer = createMemoryServer({ workspaceRoot: WORKSPACE_ROOT });
 
 type Env = { Variables: { parsedBody: unknown } };
 
+type McpToolsCallBody = {
+  method?: string;
+  params?: {
+    name?: string;
+    arguments?: unknown;
+  };
+};
+
+type McpResponseBody = {
+  result?: {
+    structuredContent?: unknown;
+    content?: Array<{ text?: string }>;
+  };
+  error?: unknown;
+};
+
 const transport = new WebStandardStreamableHTTPServerTransport();
 await mcpServer.connect(transport);
 
@@ -192,7 +208,7 @@ app.use('*', async (c, next) => {
   let args: unknown = {};
 
   if (path === '/mcp') {
-    const body: any = c.get('parsedBody');
+    const body = c.get('parsedBody') as McpToolsCallBody | undefined;
     if (body?.method === 'tools/call' && body?.params?.name) {
       tool = body.params.name;
       args = body.params.arguments ?? {};
@@ -215,7 +231,7 @@ app.use('*', async (c, next) => {
   let result: unknown = { status: c.res?.status ?? 0 };
 
   try {
-    const json: any = await c.res.clone().json();
+    const json = (await c.res.clone().json()) as McpResponseBody;
     if (path === '/mcp') {
       if (json?.result) {
         if (json.result.structuredContent) {

--- a/packages/mcp-wallet/src/index.ts
+++ b/packages/mcp-wallet/src/index.ts
@@ -19,7 +19,7 @@ import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/
 import { hostHeaderValidation } from '@modelcontextprotocol/hono';
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
 import { z } from 'zod';
-import { mcp } from '@crucible/types';
+import { mcp, createDevtoolsReporter } from '@crucible/types';
 import {
   ListAccountsInputSchema,
   GetBalanceInputSchema,
@@ -36,6 +36,7 @@ const PORT = process.env['WALLET_MCP_PORT']
 
 const CHAIN_RPC_URL = process.env['CHAIN_RPC_URL'] ?? 'http://localhost:3100/rpc';
 const WORKSPACE_ROOT = process.env['WORKSPACE_ROOT'] ?? process.cwd();
+const devtools = createDevtoolsReporter('wallet');
 
 console.log(
   `[mcp-wallet] starting on port ${PORT} (workspaceRoot: ${WORKSPACE_ROOT}, chainRpcUrl: ${CHAIN_RPC_URL})`,
@@ -181,6 +182,72 @@ app.use('*', async (c, next) => {
   const status = c.res?.status ?? 0;
   const logFn = status >= 500 ? console.error : status >= 400 ? console.warn : console.log;
   logFn(`[mcp-wallet] ← ${status} (${ms}ms)`);
+});
+
+function walletToolForPath(path: string): string | null {
+  if (path === '/accounts') return 'list_accounts';
+  if (path.startsWith('/balance/')) return 'get_balance';
+  if (path === '/sign_tx') return 'sign_tx';
+  if (path === '/send_tx_local') return 'send_tx_local';
+  if (path === '/switch_account') return 'switch_account';
+  return null;
+}
+
+app.use('*', async (c, next) => {
+  const path = new URL(c.req.url).pathname;
+  let tool = walletToolForPath(path);
+  let args: unknown = {};
+
+  if (path === '/mcp') {
+    const body: any = c.get('parsedBody');
+    if (body?.method === 'tools/call' && body?.params?.name) {
+      tool = body.params.name;
+      args = body.params.arguments ?? {};
+    }
+  } else if (tool) {
+    args = c.req.method === 'GET' ? {} : c.get('parsedBody');
+  }
+
+  if (!tool) {
+    await next();
+    return;
+  }
+
+  const startedAt = Date.now();
+  void devtools.emitToolCall(tool, args ?? {});
+  await next();
+
+  const durationMs = Date.now() - startedAt;
+  const ok = (c.res?.status ?? 500) < 400;
+  let result: unknown = { status: c.res?.status ?? 0 };
+
+  try {
+    const json: any = await c.res.clone().json();
+    if (path === '/mcp') {
+      if (json?.result) {
+        if (json.result.structuredContent) {
+          result = json.result.structuredContent;
+        } else if (json.result.content?.[0]?.text) {
+          try {
+            result = JSON.parse(json.result.content[0].text);
+          } catch {
+            result = json.result;
+          }
+        } else {
+          result = json.result;
+        }
+      } else if (json?.error) {
+        result = json.error;
+      } else {
+        result = json;
+      }
+    } else {
+      result = json;
+    }
+  } catch {
+    // Non-JSON responses still get traced with status.
+  }
+  void devtools.emitToolResult(tool, ok, result, durationMs);
 });
 
 app.openapi(listAccountsRoute, async (c) => {

--- a/packages/mcp-wallet/src/index.ts
+++ b/packages/mcp-wallet/src/index.ts
@@ -19,7 +19,12 @@ import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/
 import { hostHeaderValidation } from '@modelcontextprotocol/hono';
 import { OpenAPIHono, createRoute } from '@hono/zod-openapi';
 import { z } from 'zod';
-import { mcp, createDevtoolsReporter } from '@crucible/types';
+import {
+  mcp,
+  createDevtoolsReporter,
+  type McpToolsCallBody,
+  type McpResponseBody,
+} from '@crucible/types';
 import {
   ListAccountsInputSchema,
   GetBalanceInputSchema,
@@ -144,22 +149,6 @@ const switchAccountRoute = createRoute({
 const mcpServer = createWalletServer({ chainRpcUrl: CHAIN_RPC_URL, workspaceRoot: WORKSPACE_ROOT });
 
 type Env = { Variables: { parsedBody: unknown } };
-
-type McpToolsCallBody = {
-  method?: string;
-  params?: {
-    name?: string;
-    arguments?: unknown;
-  };
-};
-
-type McpResponseBody = {
-  result?: {
-    structuredContent?: unknown;
-    content?: Array<{ text?: string }>;
-  };
-  error?: unknown;
-};
 
 const transport = new WebStandardStreamableHTTPServerTransport();
 await mcpServer.connect(transport);

--- a/packages/mcp-wallet/src/index.ts
+++ b/packages/mcp-wallet/src/index.ts
@@ -145,6 +145,22 @@ const mcpServer = createWalletServer({ chainRpcUrl: CHAIN_RPC_URL, workspaceRoot
 
 type Env = { Variables: { parsedBody: unknown } };
 
+type McpToolsCallBody = {
+  method?: string;
+  params?: {
+    name?: string;
+    arguments?: unknown;
+  };
+};
+
+type McpResponseBody = {
+  result?: {
+    structuredContent?: unknown;
+    content?: Array<{ text?: string }>;
+  };
+  error?: unknown;
+};
+
 const transport = new WebStandardStreamableHTTPServerTransport();
 await mcpServer.connect(transport);
 
@@ -199,7 +215,7 @@ app.use('*', async (c, next) => {
   let args: unknown = {};
 
   if (path === '/mcp') {
-    const body: any = c.get('parsedBody');
+    const body = c.get('parsedBody') as McpToolsCallBody | undefined;
     if (body?.method === 'tools/call' && body?.params?.name) {
       tool = body.params.name;
       args = body.params.arguments ?? {};
@@ -222,7 +238,7 @@ app.use('*', async (c, next) => {
   let result: unknown = { status: c.res?.status ?? 0 };
 
   try {
-    const json: any = await c.res.clone().json();
+    const json = (await c.res.clone().json()) as McpResponseBody;
     if (path === '/mcp') {
       if (json?.result) {
         if (json.result.structuredContent) {

--- a/packages/types/src/devtools.ts
+++ b/packages/types/src/devtools.ts
@@ -1,0 +1,62 @@
+export type DevtoolsEvent =
+  | { type: 'tool_call'; ts: number; server: string; tool: string; args: unknown }
+  | {
+      type: 'tool_result';
+      ts: number;
+      server: string;
+      tool: string;
+      ok: boolean;
+      result: unknown;
+      durationMs: number;
+    }
+  | { type: 'container'; ts: number; subtype: string; message: string };
+
+const DEFAULT_DEVTOOLS_URL = 'http://127.0.0.1:3107/event';
+
+function withTimeout(ms: number): AbortSignal {
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), ms);
+  return controller.signal;
+}
+
+export function createDevtoolsReporter(server: string) {
+  const endpoint = process.env['DEVTOOLS_EVENT_URL'] ?? DEFAULT_DEVTOOLS_URL;
+
+  const post = async (event: DevtoolsEvent): Promise<void> => {
+    try {
+      await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(event),
+        signal: withTimeout(750),
+      });
+    } catch {
+      // Devtools must never affect MCP execution paths.
+    }
+  };
+
+  return {
+    async emitToolCall(tool: string, args: unknown): Promise<void> {
+      await post({ type: 'tool_call', ts: Date.now(), server, tool, args });
+    },
+    async emitToolResult(
+      tool: string,
+      ok: boolean,
+      result: unknown,
+      durationMs: number,
+    ): Promise<void> {
+      await post({
+        type: 'tool_result',
+        ts: Date.now(),
+        server,
+        tool,
+        ok,
+        result,
+        durationMs,
+      });
+    },
+    async emitContainer(subtype: string, message: string): Promise<void> {
+      await post({ type: 'container', ts: Date.now(), subtype, message });
+    },
+  };
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -21,5 +21,6 @@ export * from './api.ts';
 export * from './agent-events.ts';
 export * from './runtime.ts';
 export * from './preview.ts';
+export * from './devtools.ts';
 
 export * as mcp from './mcp/index.ts';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -24,3 +24,4 @@ export * from './preview.ts';
 export * from './devtools.ts';
 
 export * as mcp from './mcp/index.ts';
+export type { McpToolsCallBody, McpResponseBody } from './mcp/index.ts';

--- a/packages/types/src/mcp/index.ts
+++ b/packages/types/src/mcp/index.ts
@@ -36,6 +36,24 @@ export const DEFAULT_MCP_PORTS = {
 
 PortSchema.parse(DEFAULT_MCP_PORTS.chain);
 
+/** MCP HTTP envelope for tool/call requests (sent to /mcp endpoint). */
+export type McpToolsCallBody = {
+  method?: string;
+  params?: {
+    name?: string;
+    arguments?: unknown;
+  };
+};
+
+/** MCP HTTP envelope for responses from /mcp endpoint. */
+export type McpResponseBody = {
+  result?: {
+    structuredContent?: unknown;
+    content?: Array<{ text?: string }>;
+  };
+  error?: unknown;
+};
+
 export * as chain from './chain.ts';
 export * as compiler from './compiler.ts';
 export * as deployer from './deployer.ts';


### PR DESCRIPTION
Closes: #23 

This pull request introduces a new "devtools" service to the workspace runtime environment, adds infrastructure to track and forward tool call events from core MCP services (chain, compiler, deployer), and exposes a new API endpoint to stream devtools events per workspace. The changes span Dockerfile/service orchestration, backend API, and the MCP service implementations to enable observability and event streaming for development tools.

The most important changes are:

**Devtools Service Integration and Orchestration**
- Added the `mcp-devtools` package to the Docker build, runtime startup, and environment. The devtools service is now started alongside other MCP services, with its port (3107) exposed and tracked in environment variables and container port mappings. (`packages/backend/runtime/Dockerfile`, `entrypoint.sh`, `runtime-docker.ts`) [[1]](diffhunk://#diff-c04585c3f2ba8db99482034db442e6730f747e99e8e6835005c431a89dead13bL17-R17) [[2]](diffhunk://#diff-c04585c3f2ba8db99482034db442e6730f747e99e8e6835005c431a89dead13bR32) [[3]](diffhunk://#diff-c04585c3f2ba8db99482034db442e6730f747e99e8e6835005c431a89dead13bR43) [[4]](diffhunk://#diff-c04585c3f2ba8db99482034db442e6730f747e99e8e6835005c431a89dead13bR57-R61) [[5]](diffhunk://#diff-275d82308154a7acdfa83fd777b346c8baf34cea8b54898a32d187dffb77d023R36) [[6]](diffhunk://#diff-275d82308154a7acdfa83fd777b346c8baf34cea8b54898a32d187dffb77d023R320) [[7]](diffhunk://#diff-275d82308154a7acdfa83fd777b346c8baf34cea8b54898a32d187dffb77d023R413) [[8]](diffhunk://#diff-275d82308154a7acdfa83fd777b346c8baf34cea8b54898a32d187dffb77d023R423) [[9]](diffhunk://#diff-275d82308154a7acdfa83fd777b346c8baf34cea8b54898a32d187dffb77d023R436) [[10]](diffhunk://#diff-275d82308154a7acdfa83fd777b346c8baf34cea8b54898a32d187dffb77d023R471) [[11]](diffhunk://#diff-275d82308154a7acdfa83fd777b346c8baf34cea8b54898a32d187dffb77d023R498) [[12]](diffhunk://#diff-8631c38b3505b4eaddb3b5cf9240fd46a10a050a6a01c85516dd4257335ca66aR18-R33) [[13]](diffhunk://#diff-8631c38b3505b4eaddb3b5cf9240fd46a10a050a6a01c85516dd4257335ca66aR55-R76)

**Devtools Event Streaming API**
- Added a new API endpoint `/workspace/:id/devtools/events` that streams devtools events for a given workspace. This endpoint proxies the event stream from the devtools service, with appropriate permission checks and error handling if the service is not ready. (`workspace.ts`) [[1]](diffhunk://#diff-e55ce060c06bc9a8657b2e0c8b959d79eafd973076841f78c8b685cf113afc00L26-R30) [[2]](diffhunk://#diff-e55ce060c06bc9a8657b2e0c8b959d79eafd973076841f78c8b685cf113afc00R372-R413)

**Tool Call Event Reporting in MCP Services**
- Integrated a `createDevtoolsReporter` utility into the chain, compiler, and deployer MCP services. Each service now emits tool call and result events to the devtools service, including tool name, arguments, result, status, and duration, for both REST and `tools/call` requests. (`mcp-chain/src/index.ts`, `mcp-compiler/src/index.ts`, `mcp-deployer/src/index.ts`) [[1]](diffhunk://#diff-cf499f72659c1e40a03beb61f684a9119484e9aa4a0c890938bb24268bba2d70L19-R19) [[2]](diffhunk://#diff-cf499f72659c1e40a03beb61f684a9119484e9aa4a0c890938bb24268bba2d70R39) [[3]](diffhunk://#diff-cf499f72659c1e40a03beb61f684a9119484e9aa4a0c890938bb24268bba2d70R154-R169) [[4]](diffhunk://#diff-cf499f72659c1e40a03beb61f684a9119484e9aa4a0c890938bb24268bba2d70R213-R279) [[5]](diffhunk://#diff-126bf4ae171afbb1007e12ca948e41acf147f4750cb30a8c488ebbc397cca9a1L23-R23) [[6]](diffhunk://#diff-126bf4ae171afbb1007e12ca948e41acf147f4750cb30a8c488ebbc397cca9a1R43) [[7]](diffhunk://#diff-126bf4ae171afbb1007e12ca948e41acf147f4750cb30a8c488ebbc397cca9a1R122-R137) [[8]](diffhunk://#diff-126bf4ae171afbb1007e12ca948e41acf147f4750cb30a8c488ebbc397cca9a1R181-R245) [[9]](diffhunk://#diff-82a510c6ad5d0f2db9100b22e3574a7625533efd43216d6d8f20dcbf044d228fL23-R23) [[10]](diffhunk://#diff-82a510c6ad5d0f2db9100b22e3574a7625533efd43216d6d8f20dcbf044d228fR40)

**Container Event Emission**
- The runtime entrypoint script now emits structured container lifecycle events (startup, shutdown, service crash) to the devtools service, allowing it to track the state of the workspace environment. (`entrypoint.sh`) [[1]](diffhunk://#diff-8631c38b3505b4eaddb3b5cf9240fd46a10a050a6a01c85516dd4257335ca66aR18-R33) [[2]](diffhunk://#diff-8631c38b3505b4eaddb3b5cf9240fd46a10a050a6a01c85516dd4257335ca66aR55-R76)

These changes lay the groundwork for improved observability and tooling support within each workspace by enabling real-time event streaming and tracking of tool invocations across the MCP service stack.